### PR TITLE
Fix Fabric Physics, add "dead" entry checking to registries.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.dfsek.terra.getGitHash
 
-val versionObj = Version("5", "1", "2", true)
+val versionObj = Version("5", "1", "3", true)
 
 allprojects {
     version = versionObj

--- a/buildSrc/src/main/kotlin/com/dfsek/terra/DependencyConfig.kt
+++ b/buildSrc/src/main/kotlin/com/dfsek/terra/DependencyConfig.kt
@@ -18,9 +18,7 @@ fun Project.configureDependencies() {
 
     dependencies {
         "testImplementation"("org.junit.jupiter:junit-jupiter-api:5.7.0")
-        "testImplementation"("org.yaml:snakeyaml:1.27")
-        "testImplementation"("com.googlecode.json-simple:json-simple:1.1.1")
-        "testRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine:5.7.0")
+        "testImplementation"("org.junit.jupiter:junit-jupiter-engine:5.7.0")
         "compileOnly"("org.jetbrains:annotations:20.1.0")
     }
 }

--- a/buildSrc/src/main/kotlin/com/dfsek/terra/DistributionConfig.kt
+++ b/buildSrc/src/main/kotlin/com/dfsek/terra/DistributionConfig.kt
@@ -62,8 +62,14 @@ fun Project.configureDistribution() {
         archiveClassifier.set("shaded")
         setVersion(project.version)
         relocate("org.apache.commons", "com.dfsek.terra.lib.commons")
-        relocate("parsii", "com.dfsek.terra.lib.parsii")
         relocate("net.jafama", "com.dfsek.terra.lib.jafama")
+        relocate("org.objectweb.asm", "com.dfsek.terra.lib.asm")
+        relocate("com.google.errorprone", "com.dfsek.terra.lib.google.errorprone")
+        relocate("com.google.j2objc", "com.dfsek.terra.lib.google.j2objc")
+        relocate("org.checkerframework", "com.dfsek.terra.lib.checkerframework")
+        relocate("org.javax.annotation", "com.dfsek.terra.lib.javax.annotation")
+        relocate("org.json", "com.dfsek.terra.lib.json")
+        relocate("org.yaml", "com.dfsek.terra.lib.yaml")
         minimize()
     }
     convention.getPlugin<BasePluginConvention>().archivesBaseName = project.name

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -20,7 +20,8 @@ dependencies {
     "shadedApi"("org.ow2.asm:asm:9.0")
     "shadedApi"("commons-io:commons-io:2.6")
 
-    "compileOnly"("com.googlecode.json-simple:json-simple:1.1")
+    "shadedApi"("com.googlecode.json-simple:json-simple:1.1.1")
+    "shadedApi"("org.yaml:snakeyaml:1.27")
 
     "compileOnly"("com.google.guava:guava:30.0-jre")
 

--- a/common/src/main/java/com/dfsek/terra/config/pack/ConfigPack.java
+++ b/common/src/main/java/com/dfsek/terra/config/pack/ConfigPack.java
@@ -139,6 +139,7 @@ public class ConfigPack implements LoaderRegistrar {
                 selfLoader.load(packPostTemplate, new FileInputStream(pack));
                 biomeProviderBuilder = packPostTemplate.getProviderBuilder();
                 biomeProviderBuilder.build(0); // Build dummy provider to catch errors at load time.
+                checkDeadEntries(main);
             } catch(FileNotFoundException e) {
                 throw new LoadException("No pack.yml file found in " + folder.getAbsolutePath(), e);
             }
@@ -183,6 +184,7 @@ public class ConfigPack implements LoaderRegistrar {
                 selfLoader.load(packPostTemplate, file.getInputStream(pack));
                 biomeProviderBuilder = packPostTemplate.getProviderBuilder();
                 biomeProviderBuilder.build(0); // Build dummy provider to catch errors at load time.
+                checkDeadEntries(main);
             } catch(IOException e) {
                 throw new LoadException("Unable to load pack.yml from ZIP file", e);
             }
@@ -197,6 +199,16 @@ public class ConfigPack implements LoaderRegistrar {
     public static <C extends AbstractableTemplate, O> void buildAll(ConfigFactory<C, O> factory, OpenRegistry<O> registry, List<C> configTemplates, TerraPlugin main) throws LoadException {
         for(C template : configTemplates) registry.add(template.getID(), factory.build(template, main));
     }
+
+    private void checkDeadEntries(TerraPlugin main) {
+        biomeRegistry.getDeadEntries().forEach((id, value) -> main.getDebugLogger().warn("Dead entry in biome registry: '" + id + "'"));
+        paletteRegistry.getDeadEntries().forEach((id, value) -> main.getDebugLogger().warn("Dead entry in palette registry: '" + id + "'"));
+        floraRegistry.getDeadEntries().forEach((id, value) -> main.getDebugLogger().warn("Dead entry in flora registry: '" + id + "'"));
+        carverRegistry.getDeadEntries().forEach((id, value) -> main.getDebugLogger().warn("Dead entry in carver registry: '" + id + "'"));
+        treeRegistry.getDeadEntries().forEach((id, value) -> main.getDebugLogger().warn("Dead entry in tree registry: '" + id + "'"));
+        oreRegistry.getDeadEntries().forEach((id, value) -> main.getDebugLogger().warn("Dead entry in ore registry: '" + id + "'"));
+    }
+
 
     private void load(long start, TerraPlugin main) throws ConfigException {
         main.getEventManager().callEvent(new ConfigPackPreLoadEvent(this));

--- a/common/src/main/java/com/dfsek/terra/registry/OpenRegistry.java
+++ b/common/src/main/java/com/dfsek/terra/registry/OpenRegistry.java
@@ -7,18 +7,19 @@ import com.dfsek.terra.registry.exception.DuplicateEntryException;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * Registry implementation with read/write access. For internal use only.
  * @param <T>
  */
 public class OpenRegistry<T> implements Registry<T> {
-    private final Map<String, T> objects = new HashMap<>();
+    private final Map<String, Entry<T>> objects = new HashMap<>();
 
     @Override
     public T load(Type type, Object o, ConfigLoader configLoader) throws LoadException {
@@ -35,6 +36,10 @@ public class OpenRegistry<T> implements Registry<T> {
      * @param value      Value to add.
      */
     public boolean add(String identifier, T value) {
+        return add(identifier, new Entry<>(value));
+    }
+
+    protected boolean add(String identifier, Entry<T> value) {
         boolean exists = objects.containsKey(identifier);
         objects.put(identifier, value);
         return exists;
@@ -60,22 +65,22 @@ public class OpenRegistry<T> implements Registry<T> {
 
     @Override
     public T get(String identifier) {
-        return objects.get(identifier);
+        return objects.get(identifier).getValue();
     }
 
     @Override
     public void forEach(Consumer<T> consumer) {
-        objects.forEach((id, obj) -> consumer.accept(obj));
+        objects.forEach((id, obj) -> consumer.accept(obj.getRaw()));
     }
 
     @Override
     public void forEach(BiConsumer<String, T> consumer) {
-        objects.forEach(consumer);
+        objects.forEach((id, entry) -> consumer.accept(id, entry.getRaw()));
     }
 
     @Override
     public Set<T> entries() {
-        return new HashSet<>(objects.values());
+        return objects.values().stream().map(Entry::getRaw).collect(Collectors.toSet());
     }
 
     @Override
@@ -83,10 +88,41 @@ public class OpenRegistry<T> implements Registry<T> {
         return objects.keySet();
     }
 
+    public Map<String, T> getDeadEntries() {
+        Map<String, T> dead = new HashMap<>();
+        objects.forEach((id, entry) -> {
+            if(entry.dead()) dead.put(id, entry.value); // dont increment value here.
+        });
+        return dead;
+    }
+
     /**
      * Clears all entries from the registry.
      */
     public void clear() {
         objects.clear();
+    }
+
+
+    protected static final class Entry<T> {
+        private final T value;
+        private final AtomicInteger access = new AtomicInteger(0);
+
+        public Entry(T value) {
+            this.value = value;
+        }
+
+        public T getValue() {
+            access.incrementAndGet();
+            return value;
+        }
+
+        private T getRaw() {
+            return value;
+        }
+
+        public boolean dead() {
+            return access.get() == 0;
+        }
     }
 }

--- a/common/src/main/java/com/dfsek/terra/registry/config/FloraRegistry.java
+++ b/common/src/main/java/com/dfsek/terra/registry/config/FloraRegistry.java
@@ -57,7 +57,9 @@ public class FloraRegistry extends OpenRegistry<Flora> {
 
     private void addItem(String id, Callable<ConstantFlora> flora) {
         try {
-            add(id, flora.call());
+            Entry<Flora> entry = new Entry<>(flora.call());
+            entry.getValue(); // Mark as not dead.
+            add(id, entry);
         } catch(Exception e) {
             main.logger().warning("Failed to load Flora item: " + id + ": " + e.getMessage());
         }

--- a/platforms/bukkit/build.gradle.kts
+++ b/platforms/bukkit/build.gradle.kts
@@ -16,7 +16,7 @@ configureCommon()
 group = "com.dfsek.terra.bukkit"
 
 val mcVersion = "1.16.5"
-val testDir = "target/server/"
+val testDir = "target/server"
 val testMem = "3G"
 
 val paperURL = "https://papermc.io/api/v1/paper/%version%/latest/download/"
@@ -42,14 +42,14 @@ dependencies {
     "shadedImplementation"("com.google.guava:guava:30.0-jre")
 }
 
-val aikarsFlags = listOf("-XX:+UseG1GC", "-XX:+ParallelRefProcEnabled", "-XX:MaxGCPauseMillis=200",
+val jvmFlags = listOf("-XX:+UseG1GC", "-XX:+ParallelRefProcEnabled", "-XX:MaxGCPauseMillis=200",
         "-XX:+UnlockExperimentalVMOptions", "-XX:+DisableExplicitGC", "-XX:+AlwaysPreTouch",
         "-XX:G1NewSizePercent=30", "-XX:G1MaxNewSizePercent=40", "-XX:G1HeapRegionSize=8M",
         "-XX:G1ReservePercent=20", "-XX:G1HeapWastePercent=5", "-XX:G1MixedGCCountTarget=4",
         "-XX:InitiatingHeapOccupancyPercent=15", "-XX:G1MixedGCLiveThresholdPercent=90",
         "-XX:G1RSetUpdatingPauseTimePercent=5", "-XX:SurvivorRatio=32", "-XX:+PerfDisableSharedMem",
         "-XX:MaxTenuringThreshold=1", "-Dusing.aikars.flags=https://mcflags.emc.gs",
-        "-Daikars.new.flags=true", "-DIReallyKnowWhatIAmDoingISwear")
+        "-Daikars.new.flags=true", "-DIReallyKnowWhatIAmDoingISwear", "-javaagent:paperclip.jar")
 
 fun downloadPaperclip(url: String, dir: String) {
     val clip = URL(url.replace("%version%", mcVersion))
@@ -160,7 +160,7 @@ task<JavaExec>(name = "runPaper") {
     }
 
     main = "io.papermc.paperclip.Paperclip"
-    jvmArgs = aikarsFlags
+    jvmArgs = jvmFlags
     maxHeapSize = testMem
     minHeapSize = testMem
     //args = listOf("nogui")
@@ -178,7 +178,7 @@ task<JavaExec>(name = "runPurpur") {
     }
 
     main = "io.papermc.paperclip.Paperclip"
-    jvmArgs = aikarsFlags
+    jvmArgs = jvmFlags
     maxHeapSize = testMem
     minHeapSize = testMem
     //args = listOf("nogui")

--- a/platforms/bukkit/build.gradle.kts
+++ b/platforms/bukkit/build.gradle.kts
@@ -22,13 +22,6 @@ val testMem = "3G"
 val paperURL = "https://papermc.io/api/v1/paper/%version%/latest/download/"
 val purpurURL = "https://ci.pl3x.net/job/Purpur/lastSuccessfulBuild/artifact/final/purpurclip.jar"
 
-repositories {
-    mavenCentral()
-    maven { url = uri("http://maven.enginehub.org/repo/") }
-    maven { url = uri("https://repo.codemc.org/repository/maven-public") }
-    maven { url = uri("https://papermc.io/repo/repository/maven-public/") }
-}
-
 dependencies {
     "shadedApi"(project(":common"))
 
@@ -39,7 +32,7 @@ dependencies {
 
     "compileOnly"("com.sk89q.worldedit:worldedit-bukkit:7.2.0-SNAPSHOT")
 
-    "shadedImplementation"("com.google.guava:guava:30.0-jre")
+    "shadedApi"("com.google.guava:guava:30.0-jre")
 }
 
 val jvmFlags = listOf("-XX:+UseG1GC", "-XX:+ParallelRefProcEnabled", "-XX:MaxGCPauseMillis=200",
@@ -189,6 +182,7 @@ task<JavaExec>(name = "runPurpur") {
 tasks.named<ShadowJar>("shadowJar") {
     relocate("org.bstats.bukkit", "com.dfsek.terra.lib.bstats")
     relocate("io.papermc.lib", "com.dfsek.terra.lib.paperlib")
+    relocate("com.google.common", "com.dfsek.terra.lib.google.common")
 }
 
 publishing {

--- a/platforms/bukkit/src/main/java/com/dfsek/terra/bukkit/listeners/TerraListener.java
+++ b/platforms/bukkit/src/main/java/com/dfsek/terra/bukkit/listeners/TerraListener.java
@@ -22,7 +22,9 @@ public class TerraListener implements EventListener {
     public void injectTrees(ConfigPackPreLoadEvent event) {
         for(TreeType value : TreeType.values()) {
             try {
-                event.getPack().getTreeRegistry().add(BukkitAdapter.TREE_TRANSFORMER.translate(value), new BukkitTree(value, main));
+                String id = BukkitAdapter.TREE_TRANSFORMER.translate(value);
+                event.getPack().getTreeRegistry().add(id, new BukkitTree(value, main));
+                event.getPack().getTreeRegistry().get(id); // Platform trees should never be marked "dead"
             } catch(DuplicateEntryException ignore) { // If another addon has already registered trees, do nothing.
             }
         }

--- a/platforms/fabric/build.gradle.kts
+++ b/platforms/fabric/build.gradle.kts
@@ -21,19 +21,12 @@ group = "com.dfsek.terra.fabric"
 
 dependencies {
     "shadedApi"(project(":common"))
-    "shadedImplementation"("org.yaml:snakeyaml:1.27")
-    "shadedImplementation"("com.googlecode.json-simple:json-simple:1.1.1")
 
     "minecraft"("com.mojang:minecraft:1.16.5")
     "mappings"("net.fabricmc:yarn:1.16.5+build.5:v2")
     "modImplementation"("net.fabricmc:fabric-loader:0.11.2")
 
     "modImplementation"("net.fabricmc.fabric-api:fabric-api:0.31.0+1.16")
-}
-
-tasks.named<ShadowJar>("shadowJar") {
-    relocate("org.json", "com.dfsek.terra.lib.json")
-    relocate("org.yaml", "com.dfsek.terra.lib.yaml")
 }
 
 

--- a/platforms/fabric/src/main/java/com/dfsek/terra/fabric/world/block/FabricBlock.java
+++ b/platforms/fabric/src/main/java/com/dfsek/terra/fabric/world/block/FabricBlock.java
@@ -21,7 +21,7 @@ public class FabricBlock implements Block {
 
     @Override
     public void setBlockData(BlockData data, boolean physics) {
-        delegate.worldAccess.setBlockState(delegate.position, ((FabricBlockData) data).getHandle(), physics ? 3 : 1042, 0);
+        delegate.worldAccess.setBlockState(delegate.position, ((FabricBlockData) data).getHandle(), physics ? 3 : 1042);
     }
 
     @Override

--- a/platforms/fabric/src/main/java/com/dfsek/terra/fabric/world/block/FabricBlock.java
+++ b/platforms/fabric/src/main/java/com/dfsek/terra/fabric/world/block/FabricBlock.java
@@ -9,6 +9,7 @@ import com.dfsek.terra.api.platform.block.state.BlockState;
 import com.dfsek.terra.fabric.world.FabricAdapter;
 import com.dfsek.terra.fabric.world.block.state.FabricBlockState;
 import com.dfsek.terra.fabric.world.handles.world.FabricWorldAccess;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldAccess;
 
@@ -22,6 +23,9 @@ public class FabricBlock implements Block {
     @Override
     public void setBlockData(BlockData data, boolean physics) {
         delegate.worldAccess.setBlockState(delegate.position, ((FabricBlockData) data).getHandle(), physics ? 3 : 1042);
+        if(physics && ((FabricBlockData) data).getHandle().getBlock() instanceof FluidBlock) {
+            delegate.worldAccess.getFluidTickScheduler().schedule(delegate.position, ((FluidBlock) ((FabricBlockData) data).getHandle().getBlock()).getFluidState(((FabricBlockData) data).getHandle()).getFluid(), 0);
+        }
     }
 
     @Override


### PR DESCRIPTION
This minor update PR adds checks for "dead" registry entries (entries that were loaded but never accessed), and fixes block update physics application on Fabric. The dead entry check is useful for pack developers, who may wish to easily know if any configs in their packs are unused. The warnings are only printed if debug mode is enabled.

Fixes #116 
Fixes #102 
Closes #115 