### PR TITLE
Publish remapped jars

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {
-            artifact(tasks["sourcesJar"])
-            artifact(tasks["jar"])
+            artifact(tasks["remapSourcesJar"])
+            artifact(tasks["remapJar"])
         }
     }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {
-            artifact(tasks["remapSourcesJar"])
-            artifact(tasks["remapJar"])
+            artifact(tasks["sourcesJar"])
+            artifact(tasks["jar"])
         }
     }
 

--- a/platforms/fabric/build.gradle.kts
+++ b/platforms/fabric/build.gradle.kts
@@ -62,8 +62,8 @@ tasks.register<TaskModrinthUpload>("publishModrinth") {
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {
-            artifact(tasks["sourcesJar"])
-            artifact(tasks["jar"])
+            artifact(tasks["remapSourcesJar"])
+            artifact(tasks["remapJar"])
         }
     }
 


### PR DESCRIPTION
https://fabricmc.net/wiki/documentation:fabric_loom#publishing
> The output of the remapJar task is generally the artifact that should be published, NOT the output of the jar task.
Also solves the problem of the counter-intuitive dependency declaration