### PR TITLE
Patch version 6.0.1

### DIFF
--- a/buildSrc/src/main/kotlin/AddonConfig.kt
+++ b/buildSrc/src/main/kotlin/AddonConfig.kt
@@ -12,6 +12,7 @@ import kotlin.streams.asStream
  * Configures a directory where addons will be put.
  */
 fun Project.addonDir(dir: File, task: Task) {
+    task.dependsOn("compileAddons")
     task.doFirst {
         dir.parentFile.mkdirs()
         matchingAddons(dir) {

--- a/common/addons/structure-terrascript-loader/src/main/java/com/dfsek/terra/addons/terrascript/parser/lang/operations/statements/EqualsStatement.java
+++ b/common/addons/structure-terrascript-loader/src/main/java/com/dfsek/terra/addons/terrascript/parser/lang/operations/statements/EqualsStatement.java
@@ -32,7 +32,7 @@ public class EqualsStatement extends BinaryOperation<Object, Boolean> {
             return FastMath.abs(l.doubleValue() - r.doubleValue()) <= EPSILON;
         }
         
-        return left.equals(rightUnwrapped);
+        return leftUnwrapped.equals(rightUnwrapped);
     }
     
     

--- a/common/addons/structure-terrascript-loader/src/main/java/com/dfsek/terra/addons/terrascript/script/StructureScript.java
+++ b/common/addons/structure-terrascript-loader/src/main/java/com/dfsek/terra/addons/terrascript/script/StructureScript.java
@@ -99,7 +99,7 @@ public class StructureScript implements Structure, Keyed<StructureScript> {
                 .registerFunction("rotationDegrees", new ZeroArgFunctionBuilder<>(arguments -> arguments.getRotation().getDegrees(),
                                                                                   Returnable.ReturnType.NUMBER))
                 .registerFunction("print",
-                                  new UnaryStringFunctionBuilder(string -> LOGGER.debug("[TerraScript:{}] {}", id, string)))
+                                  new UnaryStringFunctionBuilder(string -> LOGGER.info("[TerraScript:{}] {}", id, string)))
                 .registerFunction("abs", new UnaryNumberFunctionBuilder(number -> FastMath.abs(number.doubleValue())))
                 .registerFunction("pow2", new UnaryNumberFunctionBuilder(number -> FastMath.pow2(number.doubleValue())))
                 .registerFunction("pow", new BinaryNumberFunctionBuilder(

--- a/platforms/bukkit/nms/v1_18_R2/src/main/java/com/dfsek/terra/bukkit/nms/v1_18_R2/NMSChunkGeneratorDelegate.java
+++ b/platforms/bukkit/nms/v1_18_R2/src/main/java/com/dfsek/terra/bukkit/nms/v1_18_R2/NMSChunkGeneratorDelegate.java
@@ -54,7 +54,7 @@ public class NMSChunkGeneratorDelegate extends ChunkGenerator {
     private final long seed;
     
     private final Map<ConcentricRingsStructurePlacement, Lazy<List<ChunkCoordIntPair>>> h = new Object2ObjectArrayMap<>();
-    
+    private static final Lazy<List<ChunkCoordIntPair>> EMPTY = Lazy.lazy(List::of);
     
     
     public NMSChunkGeneratorDelegate(ChunkGenerator vanilla, ConfigPack pack, NMSBiomeProvider biomeProvider, long seed) {
@@ -154,7 +154,7 @@ public class NMSChunkGeneratorDelegate extends ChunkGenerator {
     @Override
     public List<ChunkCoordIntPair> a(ConcentricRingsStructurePlacement concentricringsstructureplacement) {
         this.i();
-        return this.h.get(concentricringsstructureplacement).value();
+        return this.h.getOrDefault(concentricringsstructureplacement, EMPTY).value();
     }
     
     private volatile boolean rings = false;


### PR DESCRIPTION
Version 6.0.1 changes:

* Fixed `==` comparison of Strings in TerraScript
* Fixed potential NPE on Bukkit
* Promoted TerraScript `print` function to info-level log
* Fixed `runClient` dependency on addon compilation