### PR TITLE
Fix type mismatch

### DIFF
--- a/buildSrc/src/main/kotlin/DistributionConfig.kt
+++ b/buildSrc/src/main/kotlin/DistributionConfig.kt
@@ -1,6 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import java.io.File
 import java.io.FileWriter
+import java.net.URI
 import java.net.URL
 import java.nio.file.FileSystems
 import java.nio.file.Files
@@ -44,7 +45,7 @@ fun Project.configureDistribution() {
         
         doLast {
             // https://github.com/johnrengelman/shadow/issues/111
-            val dest = tasks.named<ShadowJar>("shadowJar").get().archiveFile.get().asFile.toURI()
+            val dest = URI.create("jar:" + tasks.named<ShadowJar>("shadowJar").get().archiveFile.get().asFile.toURI())
             
             FileSystems.newFileSystem(dest, mapOf("create" to "false"), null).use { fs ->
                 forSubProjects(":common:addons") {

--- a/buildSrc/src/main/kotlin/DistributionConfig.kt
+++ b/buildSrc/src/main/kotlin/DistributionConfig.kt
@@ -44,7 +44,7 @@ fun Project.configureDistribution() {
         
         doLast {
             // https://github.com/johnrengelman/shadow/issues/111
-            val dest = tasks.named<ShadowJar>("shadowJar").get().archiveFile.get().asFile.toPath()
+            val dest = tasks.named<ShadowJar>("shadowJar").get().archiveFile.get().asFile.toURI()
             
             FileSystems.newFileSystem(dest, mapOf("create" to "false"), null).use { fs ->
                 forSubProjects(":common:addons") {


### PR DESCRIPTION
Just pulled the master branch and got the error:

`C:\Users\{owner}\IdeaProjects\Terra\buildSrc\src\main\kotlin\DistributionConfig.kt: (49, 39): Type mismatch: inferred type is Path! but URI! was expected`

Resolves this and subsequent `Path component should be '/'` on Windows [10].

- [x] I am the original author of this code, and I am willing to release it
under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html).