### PR TITLE
Calculate noise3d generator slant with dot product

### DIFF
--- a/common/addons/chunk-generator-noise-3d/src/main/java/com/dfsek/terra/addons/chunkgenerator/config/palette/BiomePaletteTemplate.java
+++ b/common/addons/chunk-generator-noise-3d/src/main/java/com/dfsek/terra/addons/chunkgenerator/config/palette/BiomePaletteTemplate.java
@@ -75,15 +75,15 @@ public class BiomePaletteTemplate implements ObjectTemplate<PaletteInfo> {
         }
         
         TreeMap<Double, PaletteHolder> slantLayers = new TreeMap<>();
-        double minThreshold = Double.MAX_VALUE;
+        double maxThreshold = Double.MIN_VALUE;
         
         for(SlantLayer layer : slant) {
             double threshold = layer.getThreshold();
-            if(threshold < minThreshold) minThreshold = threshold;
+            if(threshold > maxThreshold) maxThreshold = threshold;
             slantLayers.put(threshold, layer.getPalette());
         }
         
-        return new PaletteInfo(builder.build(), SlantHolder.of(slantLayers, minThreshold), oceanPalette, seaLevel, slantDepth,
+        return new PaletteInfo(builder.build(), SlantHolder.of(slantLayers, maxThreshold), oceanPalette, seaLevel, slantDepth,
                                updatePalette);
     }
 }

--- a/common/addons/chunk-generator-noise-3d/src/main/java/com/dfsek/terra/addons/chunkgenerator/palette/SlantHolder.java
+++ b/common/addons/chunk-generator-noise-3d/src/main/java/com/dfsek/terra/addons/chunkgenerator/palette/SlantHolder.java
@@ -14,39 +14,39 @@ import java.util.TreeMap;
 
 public class SlantHolder {
     private final TreeMap<Double, PaletteHolder> layers;
-    private final double minSlope;
+    private final double maxSlant;
     
-    private SlantHolder(TreeMap<Double, PaletteHolder> layers, double minSlope) {
+    private SlantHolder(TreeMap<Double, PaletteHolder> layers, double maxSlant) {
         this.layers = layers;
-        this.minSlope = minSlope;
+        this.maxSlant = maxSlant;
     }
     
-    public static SlantHolder of(TreeMap<Double, PaletteHolder> layers, double minSlope) {
+    public static SlantHolder of(TreeMap<Double, PaletteHolder> layers, double maxSlant) {
         if(layers.size() == 1) {
             Entry<Double, PaletteHolder> firstEntry = layers.firstEntry();
-            return new Single(firstEntry.getValue(), minSlope);
+            return new Single(firstEntry.getValue(), maxSlant);
         }
-        return new SlantHolder(layers, minSlope);
+        return new SlantHolder(layers, maxSlant);
     }
     
     public boolean isEmpty() {
         return layers.isEmpty();
     }
     
-    public PaletteHolder getPalette(double slope) {
-        return layers.floorEntry(slope).getValue();
+    public PaletteHolder getPalette(double slant) {
+        return layers.ceilingEntry(slant).getValue();
     }
     
-    public double getMinSlope() {
-        return minSlope;
+    public double getMaxSlant() {
+        return maxSlant;
     }
     
     private static final class Single extends SlantHolder {
         
         private final PaletteHolder layers;
         
-        public Single(PaletteHolder layers, double minSlope) {
-            super(of(minSlope, layers), minSlope);
+        public Single(PaletteHolder layers, double maxSlant) {
+            super(of(maxSlant, layers), maxSlant);
             this.layers = layers;
         }
         
@@ -57,7 +57,7 @@ public class SlantHolder {
         }
         
         @Override
-        public PaletteHolder getPalette(double slope) {
+        public PaletteHolder getPalette(double slant) {
             return layers;
         }
     }


### PR DESCRIPTION
# Pull Request

## Brief description.

Changes the slant calculation to be based on the dot product of the y unit vector and a surface normal approximation.

### What Issues Does This Fix?

This fix should allow for slant to behave more predictably regardless of the terrain sampler. Rather than thresholds being 
very specific to the terrain sampler outputs, this normalizes the thresholds between [-1, 1] according to the dot product calculation, such that calculations matches the visible slant of terrain.

The current approximate derivatives which does not necessarily match the slant of terrain, which is especially noticeable when introducing 3d noise into height map based terrain:

![2022-08-15_10 47 49](https://user-images.githubusercontent.com/73215501/184561686-a74cc78a-a6fb-4d2a-9658-1f0df0ba6018.png)

Compared to with dot products:
![2022-08-15_10 46 15](https://user-images.githubusercontent.com/73215501/184561703-4d6bf6f3-c51b-4e7d-afb7-70f6cbc4f4b1.png)

Here's a dot product visualization:
![image](https://user-images.githubusercontent.com/73215501/184561916-86cb36ff-bd43-4f3c-a4ec-0bb05efc0ba2.png)

## Licensing

<!-- In order to be accepted, your changes must be under the GPLv3 license. Please check one of the following: -->

- [x] I am the original author of this code, and I am willing to release it
  under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html).
- [ ] I am not the original author of this code, but it is in public domain or
  released under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html) or a
  compatible license.
    <!--
      Please provide reliable evidence of this.
      NOTE: for compatible licenses, you must make sure to add the included license somewhere in the program, if so required.
      (And even if it's not required, it's still nice to do it. Also add attribution somewhere.)
    -->

## Affects of the PR

Thresholds will need to be re-adjusted to the [-1, 1] range:
* 1 = terrain facing upwards
* 0 = terrain facing outwards (e.g a flat wall)
* -1 = terrain facing downwards
The palette for the next greatest threshold will be used, (currently this logic is flipped for derivatives), or the main defined palette
if there is no upper threshold. (This is similar to how palettes are specified according to the highest absolute y level defined).

#### Types of changes

- [x] Bug Fix <!-- Anything which fixes an issue in Terra. -->
- [ ] Build system <!-- Anything which pretain to the build system. -->
- [ ] Documentation <!-- Anything which adds or improves documentation for existing features. -->
- [ ] New Feature <!-- Anything which adds new functionality to Terra. -->
- [ ] Performance <!-- Anything which is imrpoves the performance of Terra. -->
- [x] Refactoring <!-- Anything which does not add any new code, only moves code around. -->
- [ ] Repository <!-- Anything which affects the repository. Eg. changes to the `README.md` file. -->
- [ ] Revert <!-- Anything which reverts previous commits. -->
- [ ] Style <!-- Anything which updates style. -->
- [ ] Tests <!-- Anything which adds or updates tests. -->
- [ ] Translation <!-- Anything which is internationalizing the Terra program to other languages. -->

#### Compatiblity

- [x] Breaking
  change <!-- A fix, or a feature, that breaks some previous functionality to Terra. -->
- [ ] Non-Breaking change.
    <!--
        A change which does not break *any* previous functionality of Terra.
        (ie. is backwards compatible and will work with *any* previously existing supported features.
        Note: if a feature is annotated with @Incubating, @Preview, @Experimental,
        or is in a package called something similar to the previous annotations,
        then you may push breaking changes to only THOSE parts of Terra.)
    -->

#### Contribution Guidelines.

- [x] I have read
  the [`CONTRIBUTING.md`](https://github.com/PolyhedralDev/Terra/blob/master/CONTRIBUTING.md)
  document in the root of the git repository.
- [ ] My code follows the code style for this
  project. <!-- There is an included `.editorconfig` file in the base of the repo. Please use a plugin for your IDE of choice that follows those settings. -->

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Testing

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
    <!--
        If it only introduces small changes, you don't need to add tests.
        But if you add big changes, you should probably at least write *some* testing, where applicable.
    -->
