### PR TITLE
fix #378

### DIFF
--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/handles/BukkitWorldHandle.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/handles/BukkitWorldHandle.java
@@ -52,7 +52,12 @@ public class BukkitWorldHandle implements WorldHandle {
     @Override
     public @NotNull EntityType getEntity(@NotNull String id) {
         if(!id.startsWith("minecraft:")) throw new IllegalArgumentException("Invalid entity identifier " + id);
-        return new BukkitEntityType(org.bukkit.entity.EntityType.valueOf(id.toUpperCase(Locale.ROOT).substring(10)));
+        String entityID = id.toUpperCase(Locale.ROOT).substring(10);
+        
+        return new BukkitEntityType(switch(entityID) {
+            case "END_CRYSTAL" -> org.bukkit.entity.EntityType.ENDER_CRYSTAL;
+            case "ENDER_CRYSTAL" -> throw new IllegalArgumentException("Invalid entity identifier " + id); // make sure this issue can't happen the other way around.
+            default -> org.bukkit.entity.EntityType.valueOf(entityID);
+        });
     }
-    
 }


### PR DESCRIPTION
Uses a switch to rename `END_CRYSTAL` to `ENDER_CRYSTAL` on Bukkit. Fixes #378 

Also makes sure Bukkit config devs can't use `ENDER_CRYSTAL` in their configs, to ensure compatibility with other platforms.