### PR TITLE
Prevent exception with other world generators

### DIFF
--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/TerraBukkitPlugin.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/TerraBukkitPlugin.java
@@ -189,6 +189,7 @@ public class TerraBukkitPlugin extends JavaPlugin {
     @Override
     public @Nullable
     ChunkGenerator getDefaultWorldGenerator(@NotNull String worldName, String id) {
+        if (id == null || id.trim().equals("")) { return null; }
         return new BukkitChunkGeneratorWrapper(generatorMap.computeIfAbsent(worldName, name -> {
             ConfigPack pack = platform.getConfigRegistry().getByID(id).orElseThrow(
                 () -> new IllegalArgumentException("No such config pack \"" + id + "\""));


### PR DESCRIPTION
# Pull Request

## Description

<!-- Include a description of the PR here -->

When defining generators for [worlds that Bukkit loads by default](https://bukkit.fandom.com/wiki/Bukkit.yml#*OPTIONAL*_worlds), other plugins may trigger an exception within Terra as they, of course, do not use colons followed by pack IDs. Here is an example of such using [PlotSquared](https://www.spigotmc.org/resources/plotsquared-v7.77506/) on Paper 1.20.4:

```
[11:45:46] [Server thread/WARN]: java.lang.IllegalArgumentException: No such config pack ""
[11:45:46] [Server thread/WARN]: 	at Terra-bukkit-6.4.3-BETA+ab60f14ff-shaded.jar//com.dfsek.terra.bukkit.TerraBukkitPlugin.lambda$getDefaultWorldGenerator$2(TerraBukkitPlugin.java:194)
[11:45:46] [Server thread/WARN]: 	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
[11:45:46] [Server thread/WARN]: 	at Terra-bukkit-6.4.3-BETA+ab60f14ff-shaded.jar//com.dfsek.terra.bukkit.TerraBukkitPlugin.lambda$getDefaultWorldGenerator$3(TerraBukkitPlugin.java:193)
[11:45:46] [Server thread/WARN]: 	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1220)
[11:45:46] [Server thread/WARN]: 	at Terra-bukkit-6.4.3-BETA+ab60f14ff-shaded.jar//com.dfsek.terra.bukkit.TerraBukkitPlugin.getDefaultWorldGenerator(TerraBukkitPlugin.java:192)
[11:45:46] [Server thread/WARN]: 	at plotsquared-bukkit-7.3.2-Premium.jar//com.plotsquared.bukkit.util.BukkitSetupUtils.updateGenerators(BukkitSetupUtils.java:80)
[11:45:46] [Server thread/WARN]: 	at plotsquared-bukkit-7.3.2-Premium.jar//com.plotsquared.bukkit.BukkitPlatform.lambda$onEnable$1(BukkitPlatform.java:444)
[11:45:46] [Server thread/WARN]: 	at plotsquared-bukkit-7.3.2-Premium.jar//com.plotsquared.bukkit.util.task.BukkitPlotSquaredTask.runTask(BukkitPlotSquaredTask.java:39)
[11:45:46] [Server thread/WARN]: 	at plotsquared-bukkit-7.3.2-Premium.jar//com.plotsquared.core.util.task.PlotSquaredTask.run(PlotSquaredTask.java:44)
[11:45:46] [Server thread/WARN]: 	at org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftTask.run(CraftTask.java:101)
[11:45:46] [Server thread/WARN]: 	at org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:480)
[11:45:46] [Server thread/WARN]: 	at net.minecraft.server.MinecraftServer.w(MinecraftServer.java:1143)
[11:45:46] [Server thread/WARN]: 	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:321)
[11:45:46] [Server thread/WARN]: 	at java.base/java.lang.Thread.run(Thread.java:833)
```

This PR resolves the issue by simply returning null when the generator being identified lacks an ID.

<!--
If applicable, include 'Fixes #XXXX' or 'Closes #XXXX' for any related open issues.
This helps us relate, track, and close the relevant issues.
-->

Fixes https://discord.com/channels/715448651786485780/1106498518807494676

## Checklist

<!--
Select the options below that apply.
You must put an x in all the boxes that it applies to. (Like this: [x])
-->

#### Mandatory checks

- [x] The base branch of this PR is an unreleased version branch (that has a `ver/` prefix)
  or is a branch that is intended to be merged into a version branch.
  <!--
  This is not applicable if the PR is a version branch itself.
  PRs for new versions should use the `master` branch instead.
  -->
- [x] There are no already existing PRs that provide the same changes.
  <!-- If this is not applicable, the PR will be removed as a duplicate. -->
- [x] The PR is within the scope of Terra (i.e. is something a configurable terrain generator should be doing).
- [ ] Changes follow the code style for this project.
  <!-- There is an included `.editorconfig` file in the base of the repo. Please use a plugin for your IDE of choice that follows those settings. -->
- [x] I have read the [`CONTRIBUTING.md`](https://github.com/PolyhedralDev/Terra/blob/master/CONTRIBUTING.md)
  document in the root of the git repository.

#### Types of changes

- [x] Bug Fix <!-- Changes include bug fixes. -->
- [ ] Build system <!-- Changes the build system. -->
- [ ] Documentation <!-- Changes add to or improve documentation. -->
- [ ] New Feature <!-- Changes add new functionality to Terra. -->
- [ ] Performance <!-- Changes improve the performance of Terra. -->
- [ ] Refactoring <!-- Changes do not add any new code, only moves code around. -->
- [ ] Repository <!-- Changes affect the repository. E.g. changes to the `README.md` file. -->
- [ ] Revert <!-- Changes revert previous commits. -->
- [ ] Style <!-- Changes update style, namely the .editorconfig file. -->
- [ ] Tests <!-- Changes add or update tests. -->
- [ ] Translation <!-- Changes include translations to other languages for Terra. -->

#### Compatibility

<!-- The following options determine if the PR pertains to a major, minor, or patch version bump -->

- [ ] Introduces a breaking change
  <!--
  Breaking changes are any fix or feature that breaks some previous functionality to Terra / is not backwards compatible.
  Breaking changes do not include:
    - changes that are backwards compatible and will work with *any* previously existing supported features.
    - changes to code marked as in a pre-release
      state (annotated with @Incubating, @Preview, @Experimental
      or in a package called something similar to the previous annotations)
  -->
- [ ] Introduces new functionality in a backwards compatible way.
- [x] Introduces bug fixes

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Testing

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  <!--
  Tests are typically not necessary for small changes.
  Including *some* testing is recommended for large changes where applicable.
  -->

#### Licensing

<!-- In order to be accepted, your changes must be under the GPLv3 license. Please check one of the following: -->

- [x] I am the original author of this code, and I am willing to
  release it under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html).
- [ ] I am not the original author of this code, but it is in public domain or
  released under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html) or a compatible license.
  <!--
  Please provide reliable evidence of this.
  NOTE: for compatible licenses, you must make sure to add the included license somewhere in the program, if so required.
  (And even if it's not required, it's still nice to do it. Also add attribution somewhere.)
  -->
