### PR TITLE
Add salt argument to sampler functions in EXPRESSION samplers

### DIFF
--- a/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/noise/NoiseFunction2.java
+++ b/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/noise/NoiseFunction2.java
@@ -28,12 +28,12 @@ public class NoiseFunction2 implements DynamicFunction {
 
     @Override
     public double eval(Context context, double... args) {
-        return gen.noise(((SeedContext) context).getSeed(), args[0], args[1]);
+        return gen.noise(((SeedContext) context).getSeed() + (long) args[2], args[0], args[1]);
     }
 
     @Override
     public int getArgNumber() {
-        return 2;
+        return 3;
     }
 
     @Override

--- a/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/noise/NoiseFunction3.java
+++ b/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/noise/NoiseFunction3.java
@@ -28,12 +28,12 @@ public class NoiseFunction3 implements DynamicFunction {
 
     @Override
     public double eval(Context context, double... args) {
-        return gen.noise(((SeedContext) context).getSeed(), args[0], args[1], args[2]);
+        return gen.noise(((SeedContext) context).getSeed() + (long) args[3], args[0], args[1], args[2]);
     }
 
     @Override
     public int getArgNumber() {
-        return 3;
+        return 4;
     }
 
     @Override


### PR DESCRIPTION
# Pull Request

## Description

This is a naïve implementation of #371. An additional, mandatory argument is included for all sampler functions which is cast to `long`. It seems to work and comply with the issue, but is inelegant and suspiciously simple.

In theory, this could be a non-breaking change if it used function overloading or optional arguments, but to my limited knowledge, this isn't currently possible. Every function is required to provide a static number of arguments through `com.dfsek.paralithic.functions.Function#getArgNumber(int)` and no two functions can share the same name as they're stored in a `Map<String, Function>`.

I request any feedback on if this actually solves the issue or if it could be improved in any way so that I may learn and be better able to contribute.

Closes #371

### Changelog

- [x] Additional argument for sampler functions in `EXPRESSION`s.

## Checklist

#### Mandatory checks

- [x] The base branch of this PR is an unreleased version branch (that has a `ver/` prefix)
  or is a branch that is intended to be merged into a version branch.
- [x] There are no already existing PRs that provide the same changes.
- [x] The PR is within the scope of Terra (i.e. is something a configurable terrain generator should be doing).
- [x] Changes follow the code style for this project.
- [x] I have read the [`CONTRIBUTING.md`](https://github.com/PolyhedralDev/Terra/blob/master/CONTRIBUTING.md)
  document in the root of the git repository.

#### Types of changes

- [ ] Bug Fix <!-- Changes include bug fixes. -->
- [ ] Build system <!-- Changes the build system. -->
- [ ] Documentation <!-- Changes add to or improve documentation. -->
- [x] New Feature <!-- Changes add new functionality to Terra. -->
- [ ] Performance <!-- Changes improve the performance of Terra. -->
- [ ] Refactoring <!-- Changes do not add any new code, only moves code around. -->
- [ ] Repository <!-- Changes affect the repository. E.g. changes to the `README.md` file. -->
- [ ] Revert <!-- Changes revert previous commits. -->
- [ ] Style <!-- Changes update style, namely the .editorconfig file. -->
- [ ] Tests <!-- Changes add or update tests. -->
- [ ] Translation <!-- Changes include translations to other languages for Terra. -->

#### Compatibility

<!-- The following options determine if the PR pertains to a major, minor, or patch version bump -->

- [x] Introduces a breaking change
- [ ] Introduces new functionality in a backwards compatible way.
- [ ] Introduces bug fixes

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Testing

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  <!--
  Tests are typically not necessary for small changes.
  Including *some* testing is recommended for large changes where applicable.
  -->

#### Licensing

<!-- In order to be accepted, your changes must be under the GPLv3 license. Please check one of the following: -->

- [x] I am the original author of this code, and I am willing to
  release it under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html).
- [ ] I am not the original author of this code, but it is in public domain or
  released under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html) or a compatible license.
  <!--
  Please provide reliable evidence of this.
  NOTE: for compatible licenses, you must make sure to add the included license somewhere in the program, if so required.
  (And even if it's not required, it's still nice to do it. Also add attribution somewhere.)
  -->
