### PR TITLE
Add salted version of sampler functions in EXPRESSION samplers

### DIFF
--- a/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/FunctionUtil.java
+++ b/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/FunctionUtil.java
@@ -26,7 +26,7 @@ public class FunctionUtil {
             functionMap.put(entry.getKey(), UserDefinedFunction.newInstance(entry.getValue()));
         }
         samplers.forEach((id, sampler) -> {
-            if (sampler.getDimensions() == 2) {
+            if(sampler.getDimensions() == 2) {
                 functionMap.put(id, new NoiseFunction2(sampler.getSampler()));
                 functionMap.put(id + "Salted", new SaltedNoiseFunction2(sampler.getSampler()));
             } else {

--- a/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/FunctionUtil.java
+++ b/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/FunctionUtil.java
@@ -11,6 +11,8 @@ import com.dfsek.terra.addons.noise.config.templates.FunctionTemplate;
 import com.dfsek.terra.addons.noise.paralithic.defined.UserDefinedFunction;
 import com.dfsek.terra.addons.noise.paralithic.noise.NoiseFunction2;
 import com.dfsek.terra.addons.noise.paralithic.noise.NoiseFunction3;
+import com.dfsek.terra.addons.noise.paralithic.noise.SaltedNoiseFunction2;
+import com.dfsek.terra.addons.noise.paralithic.noise.SaltedNoiseFunction3;
 
 
 public class FunctionUtil {
@@ -23,10 +25,15 @@ public class FunctionUtil {
         for(Map.Entry<String, FunctionTemplate> entry : functions.entrySet()) {
             functionMap.put(entry.getKey(), UserDefinedFunction.newInstance(entry.getValue()));
         }
-        samplers.forEach((id, sampler) -> functionMap.put(id,
-            sampler.getDimensions() == 2 ?
-            new NoiseFunction2(sampler.getSampler()) :
-            new NoiseFunction3(sampler.getSampler())));
+        samplers.forEach((id, sampler) -> {
+            if (sampler.getDimensions() == 2) {
+                functionMap.put(id, new NoiseFunction2(sampler.getSampler()));
+                functionMap.put(id + "Salted", new SaltedNoiseFunction2(sampler.getSampler()));
+            } else {
+                functionMap.put(id, new NoiseFunction3(sampler.getSampler()));
+                functionMap.put(id + "Salted", new SaltedNoiseFunction3(sampler.getSampler()));
+            }
+        });
         return functionMap;
     }
 }

--- a/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/noise/SaltedNoiseFunction2.java
+++ b/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/noise/SaltedNoiseFunction2.java
@@ -9,7 +9,7 @@ import com.dfsek.terra.api.noise.NoiseSampler;
 import org.jetbrains.annotations.NotNull;
 
 
-public class SaltedNoiseFunction2 implements DynamicFunction  {
+public class SaltedNoiseFunction2 implements DynamicFunction {
     private final NoiseSampler gen;
 
     public SaltedNoiseFunction2(NoiseSampler gen) {

--- a/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/noise/SaltedNoiseFunction2.java
+++ b/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/noise/SaltedNoiseFunction2.java
@@ -1,0 +1,38 @@
+package com.dfsek.terra.addons.noise.paralithic.noise;
+
+import com.dfsek.paralithic.functions.dynamic.Context;
+import com.dfsek.paralithic.functions.dynamic.DynamicFunction;
+import com.dfsek.paralithic.node.Statefulness;
+
+import com.dfsek.terra.api.noise.NoiseSampler;
+
+import org.jetbrains.annotations.NotNull;
+
+
+public class SaltedNoiseFunction2 implements DynamicFunction  {
+    private final NoiseSampler gen;
+
+    public SaltedNoiseFunction2(NoiseSampler gen) {
+        this.gen = gen;
+    }
+
+    @Override
+    public double eval(double... args) {
+        throw new UnsupportedOperationException("Cannot evaluate seeded function without seed context.");
+    }
+
+    @Override
+    public double eval(Context context, double... args) {
+        return gen.noise(((SeedContext) context).getSeed() + (long) args[2], args[0], args[1]);
+    }
+
+    @Override
+    public int getArgNumber() {
+        return 3;
+    }
+
+    @Override
+    public @NotNull Statefulness statefulness() {
+        return Statefulness.CONTEXTUAL;
+    }
+}

--- a/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/noise/SaltedNoiseFunction3.java
+++ b/common/addons/config-noise-function/src/main/java/com/dfsek/terra/addons/noise/paralithic/noise/SaltedNoiseFunction3.java
@@ -1,0 +1,38 @@
+package com.dfsek.terra.addons.noise.paralithic.noise;
+
+import com.dfsek.paralithic.functions.dynamic.Context;
+import com.dfsek.paralithic.functions.dynamic.DynamicFunction;
+import com.dfsek.paralithic.node.Statefulness;
+
+import com.dfsek.terra.api.noise.NoiseSampler;
+
+import org.jetbrains.annotations.NotNull;
+
+
+public class SaltedNoiseFunction3 implements DynamicFunction {
+    private final NoiseSampler gen;
+
+    public SaltedNoiseFunction3(NoiseSampler gen) {
+        this.gen = gen;
+    }
+
+    @Override
+    public double eval(double... args) {
+        throw new UnsupportedOperationException("Cannot evaluate seeded function without seed context.");
+    }
+
+    @Override
+    public double eval(Context context, double... args) {
+        return gen.noise(((SeedContext) context).getSeed() + (long) args[3], args[0], args[1], args[2]);
+    }
+
+    @Override
+    public int getArgNumber() {
+        return 4;
+    }
+
+    @Override
+    public @NotNull Statefulness statefulness() {
+        return Statefulness.CONTEXTUAL;
+    }
+}


### PR DESCRIPTION
# Pull Request

A slightly less naïve implementation of #371. Every sampler specified in an `EXPRESSION` sampler generates two functions: `sampler(Point)` and `samplerSalted(Point, double)`. The salted version requires an additional, mandatory argument for salt, per Astrash's recommendation.

May require a documentation change to record the existence of this feature and to warn against duplication of function names. Though highly unlikely, this change breaks config packs that result in name duplication.

The previous PR was closed so that the git history can be made cleaner without the need for revert commits.

Again open for any feedback at all.

Closes #371.

### Changelog

- [x] Add additional salted version of samplers in `EXPRESSION`s.

## Checklist

#### Mandatory checks

- [x] The base branch of this PR is an unreleased version branch (that has a `ver/` prefix)
  or is a branch that is intended to be merged into a version branch.
- [x] There are no already existing PRs that provide the same changes.
  <!-- If this is not applicable, the PR will be removed as a duplicate. -->
- [x] The PR is within the scope of Terra (i.e. is something a configurable terrain generator should be doing).
- [x] Changes follow the code style for this project.
  <!-- There is an included `.editorconfig` file in the base of the repo. Please use a plugin for your IDE of choice that follows those settings. -->
- [x] I have read the [`CONTRIBUTING.md`](https://github.com/PolyhedralDev/Terra/blob/master/CONTRIBUTING.md)
  document in the root of the git repository.

#### Types of changes

- [ ] Bug Fix <!-- Changes include bug fixes. -->
- [ ] Build system <!-- Changes the build system. -->
- [ ] Documentation <!-- Changes add to or improve documentation. -->
- [x] New Feature <!-- Changes add new functionality to Terra. -->
- [ ] Performance <!-- Changes improve the performance of Terra. -->
- [ ] Refactoring <!-- Changes do not add any new code, only moves code around. -->
- [ ] Repository <!-- Changes affect the repository. E.g. changes to the `README.md` file. -->
- [ ] Revert <!-- Changes revert previous commits. -->
- [ ] Style <!-- Changes update style, namely the .editorconfig file. -->
- [ ] Tests <!-- Changes add or update tests. -->
- [ ] Translation <!-- Changes include translations to other languages for Terra. -->

#### Compatibility

<!-- The following options determine if the PR pertains to a major, minor, or patch version bump -->

- [ ] Introduces a breaking change
  <!--
  Breaking changes are any fix or feature that breaks some previous functionality to Terra / is not backwards compatible.
  Breaking changes do not include:
    - changes that are backwards compatible and will work with *any* previously existing supported features.
    - changes to code marked as in a pre-release
      state (annotated with @Incubating, @Preview, @Experimental
      or in a package called something similar to the previous annotations)
  -->
- [x] Introduces new functionality in a backwards compatible way.
- [ ] Introduces bug fixes

#### Documentation

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Testing

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  <!--
  Tests are typically not necessary for small changes.
  Including *some* testing is recommended for large changes where applicable.
  -->

#### Licensing

<!-- In order to be accepted, your changes must be under the GPLv3 license. Please check one of the following: -->

- [x] I am the original author of this code, and I am willing to
  release it under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html).
- [ ] I am not the original author of this code, but it is in public domain or
  released under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html) or a compatible license.
  <!--
  Please provide reliable evidence of this.
  NOTE: for compatible licenses, you must make sure to add the included license somewhere in the program, if so required.
  (And even if it's not required, it's still nice to do it. Also add attribution somewhere.)
  -->
