### PR TITLE
feat: support world unloading

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -79,6 +79,6 @@ object Versions {
     }
     
     object Allay {
-        const val api = "1cb3bb69c6"
+        const val api = "0114e0b290"
     }
 }

--- a/platforms/allay/src/main/java/com/dfsek/terra/allay/TerraAllayPlugin.java
+++ b/platforms/allay/src/main/java/com/dfsek/terra/allay/TerraAllayPlugin.java
@@ -1,10 +1,14 @@
 package com.dfsek.terra.allay;
 
+import org.allaymc.api.eventbus.EventHandler;
+import org.allaymc.api.eventbus.event.world.WorldUnloadEvent;
 import org.allaymc.api.plugin.Plugin;
 import org.allaymc.api.registry.Registries;
+import org.allaymc.api.server.Server;
 
 import com.dfsek.terra.allay.generator.AllayGeneratorWrapper;
 import com.dfsek.terra.api.event.events.platform.PlatformInitializationEvent;
+
 
 /**
  * @author daoge_cmd
@@ -47,6 +51,11 @@ public class TerraAllayPlugin extends Plugin {
     }
 
     @Override
+    public void onEnable() {
+        Server.getInstance().getEventBus().registerListener(this);
+    }
+
+    @Override
     public boolean isReloadable() {
         return true;
     }
@@ -58,5 +67,10 @@ public class TerraAllayPlugin extends Plugin {
         } else {
             pluginLogger.error("Terra failed to reload.");
         }
+    }
+
+    @EventHandler
+    private void onWorldUnload(WorldUnloadEvent event) {
+        AllayPlatform.GENERATOR_WRAPPERS.removeIf(wrapper -> wrapper.getAllayWorldGenerator().getDimension().getWorld() == event.getWorld());
     }
 }


### PR DESCRIPTION
This PR add support for world unloading during runtime which is a new feature in the newer version of allay. 

Currently, the `AllayGeneratorWrapper` object in `AllayPlatform#GENERATOR_WRAPPERS` won't be removed after the world being unloaded. This will cause memory overflow if there are a lot of world loading and unloading operations during runtime.