### PR TITLE
Add support for 1.21.4 on Paper

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -55,8 +55,8 @@ object Versions {
 //    }
     
     object Bukkit {
-        const val minecraft = "1.21.3"
-        const val paperBuild = "$minecraft-R0.1-20241101.150401-13"
+        const val minecraft = "1.21.4"
+        const val paperBuild = "$minecraft-R0.1-20241211.212446-17"
         const val paper = paperBuild
         const val paperLib = "1.0.8"
         const val reflectionRemapper = "0.1.1"

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/nms/Initializer.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/nms/Initializer.java
@@ -54,7 +54,7 @@ public interface Initializer {
     private static Initializer constructInitializer() {
         try {
             String packageVersion = NMS;
-            if (NMS.equals("v_1_21_4")) {
+            if (NMS.equals("v1_21_4")) {
                 packageVersion = "v1_21_3";
             }
 

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/nms/Initializer.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/nms/Initializer.java
@@ -54,6 +54,9 @@ public interface Initializer {
     private static Initializer constructInitializer() {
         try {
             String packageVersion = NMS;
+            if (NMS.equals("v_1_21_4")) {
+                packageVersion = "v1_21_3";
+            }
 
             Class<?> initializerClass = Class.forName(TERRA_PACKAGE + "." + packageVersion + ".NMSInitializer");
             try {


### PR DESCRIPTION
As the NMS world generation code has not change since 1.21.3 I have simply added a version check, this jar should work for both 1.21.3 and 1.21.4