### PR TITLE
fix crash chunk generate column in generate chunk process

### DIFF
--- a/platforms/bukkit/nms/v1_21_3/src/main/java/com/dfsek/terra/bukkit/nms/v1_21_3/NMSChunkGeneratorDelegate.java
+++ b/platforms/bukkit/nms/v1_21_3/src/main/java/com/dfsek/terra/bukkit/nms/v1_21_3/NMSChunkGeneratorDelegate.java
@@ -155,7 +155,7 @@ public class NMSChunkGeneratorDelegate extends ChunkGenerator {
         BlockState[] array = new BlockState[world.getHeight()];
         WorldProperties properties = new NMSWorldProperties(seed, world);
         BiomeProvider biomeProvider = pack.getBiomeProvider();
-        for(int y = properties.getMaxHeight() - 1; y >= properties.getMinHeight(); y--) {
+        for(int y = properties.getMaxHeight(); y >= properties.getMinHeight(); y--) {
             array[y - properties.getMinHeight()] = ((CraftBlockData) delegate.getBlock(properties, x, y, z, biomeProvider)
                 .getHandle()).getState();
         }


### PR DESCRIPTION
The change removes the subtraction of one from ``properties.getMaxHeight()``, fixing a crash on version 1.21.4 with column of custom portals.