### PR TITLE
feat: initializing git submodules for workflow

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -18,6 +18,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Initialize Git Submodules
+        run: git submodule update --init --recursive
+
       - name: Set up JDK 21
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:


### PR DESCRIPTION
This PR fixed invalid allay jar, because submodules are not downloaded.

Before:
![image](https://github.com/user-attachments/assets/990b3800-32dd-41ae-9bf9-0c38c59adac0)

After:
![image](https://github.com/user-attachments/assets/b8ec4ea8-88ed-4063-bfde-82cda0de8aa9)
