### PR TITLE
Identify Moonrise worker threads correctly

### DIFF
--- a/common/implementation/base/src/main/java/com/dfsek/terra/AbstractPlatform.java
+++ b/common/implementation/base/src/main/java/com/dfsek/terra/AbstractPlatform.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -326,6 +328,28 @@ public abstract class AbstractPlatform implements Platform {
         }
         return 0;
 
+    }
+    
+    private static final String moonrise = "Moonrise";
+    public static int getMoonriseGenerationThreadsWithReflection() {
+        try {
+            Class<?> prioritisedThreadPoolClazz = Class.forName("ca.spottedleaf.concurrentutil.executor.thread.PrioritisedThreadPool");
+            Method getCoreThreadsMethod = prioritisedThreadPoolClazz.getDeclaredMethod("getCoreThreads");
+            getCoreThreadsMethod.setAccessible(true);
+            Class<?> moonriseCommonClazz = Class.forName("ca.spottedleaf.moonrise.common.util.MoonriseCommon");
+            Object pool = moonriseCommonClazz.getDeclaredField("WORKER_POOL").get(null);
+            int threads = ((Thread[]) getCoreThreadsMethod.invoke(pool)).length;
+            logger.info("{} found, setting {} generation threads.", moonrise, threads);
+            return threads;
+        } catch (ClassNotFoundException e) {
+            logger.info("{} not found.", moonrise);
+        } catch (NoSuchMethodException | NoSuchFieldException e) {
+            logger.warn("{} found, but field/method not found this probably means {0} has changed its code and " +
+                        "Terra has not updated to reflect that.", moonrise);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            logger.error("Failed to access thread values in {}, assuming 1 generation thread.", moonrise, e);
+        }
+        return 0;
     }
 
     @Override

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/PlatformImpl.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/PlatformImpl.java
@@ -57,7 +57,7 @@ public class PlatformImpl extends AbstractPlatform {
     private int generationThreads;
 
     public PlatformImpl(TerraBukkitPlugin plugin) {
-        generationThreads = getGenerationThreadsWithReflection("ca.spottedleaf.moonrise.common.util.MoonriseCommon", "WORKER_THREADS", "Moonrise");
+        generationThreads = getMoonriseGenerationThreadsWithReflection();
         if (generationThreads == 0) {
             generationThreads = 1;
         }

--- a/platforms/mixin-lifecycle/src/main/java/com/dfsek/terra/lifecycle/LifecyclePlatform.java
+++ b/platforms/mixin-lifecycle/src/main/java/com/dfsek/terra/lifecycle/LifecyclePlatform.java
@@ -45,7 +45,7 @@ public abstract class LifecyclePlatform extends ModPlatform {
     public LifecyclePlatform() {
         generationThreads = getGenerationThreadsWithReflection("com.ishland.c2me.base.common.GlobalExecutors", "GLOBAL_EXECUTOR_PARALLELISM", "C2ME");
         if (generationThreads == 0) {
-            generationThreads = getGenerationThreadsWithReflection("ca.spottedleaf.moonrise.common.util.MoonriseCommon", "WORKER_THREADS", "Moonrise");
+            generationThreads = getMoonriseGenerationThreadsWithReflection();
         } if (generationThreads == 0) {
             generationThreads = 1;
         }


### PR DESCRIPTION
# Pull Request

## Description

Correctly identify Moonrise worker threads, as it removed previous members exposed in MoonriseCommon, old code nolonger works.

The new approach now gets the `PriortisedThreadPool` member from MoonriseCommon and calling its `getCoreThreads` method.

Closes #481.

## Checklist

<!--
Select the options below that apply.
You must put an x in all the boxes that it applies to. (Like this: [x])
-->

#### Mandatory checks

- [x] The base branch of this PR is an unreleased version branch (that has a `ver/` prefix)
  or is a branch that is intended to be merged into a version branch.
  <!--
  This is not applicable if the PR is a version branch itself.
  PRs for new versions should use the `master` branch instead.
  -->
- [x] There are no already existing PRs that provide the same changes.
  <!-- If this is not applicable, the PR will be removed as a duplicate. -->
- [x] The PR is within the scope of Terra (i.e. is something a configurable terrain generator should be doing).
- [x] Changes follow the code style for this project.
  <!-- There is an included `.editorconfig` file in the base of the repo. Please use a plugin for your IDE of choice that follows those settings. -->
- [x] I have read the [`CONTRIBUTING.md`](https://github.com/PolyhedralDev/Terra/blob/master/CONTRIBUTING.md)
  document in the root of the git repository.

#### Types of changes

- [x] Bug Fix <!-- Changes include bug fixes. -->
- [ ] Build system <!-- Changes the build system. -->
- [ ] Documentation <!-- Changes add to or improve documentation. -->
- [ ] New Feature <!-- Changes add new functionality to Terra. -->
- [ ] Performance <!-- Changes improve the performance of Terra. -->
- [ ] Refactoring <!-- Changes do not add any new code, only moves code around. -->
- [ ] Repository <!-- Changes affect the repository. E.g. changes to the `README.md` file. -->
- [ ] Revert <!-- Changes revert previous commits. -->
- [ ] Style <!-- Changes update style, namely the .editorconfig file. -->
- [ ] Tests <!-- Changes add or update tests. -->
- [ ] Translation <!-- Changes include translations to other languages for Terra. -->

#### Compatibility

<!-- The following options determine if the PR pertains to a major, minor, or patch version bump -->

- [ ] Introduces a breaking change
  <!--
  Breaking changes are any fix or feature that breaks some previous functionality to Terra / is not backwards compatible.
  Breaking changes do not include:
    - changes that are backwards compatible and will work with *any* previously existing supported features.
    - changes to code marked as in a pre-release
      state (annotated with @Incubating, @Preview, @Experimental
      or in a package called something similar to the previous annotations)
  -->
- [ ] Introduces new functionality in a backwards compatible way.
- [x] Introduces bug fixes

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Testing

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  <!--
  Tests are typically not necessary for small changes.
  Including *some* testing is recommended for large changes where applicable.
  -->

#### Licensing

<!-- In order to be accepted, your changes must be under the GPLv3 license. Please check one of the following: -->

- [x] I am the original author of this code, and I am willing to
  release it under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html).
- [ ] I am not the original author of this code, but it is in public domain or
  released under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html) or a compatible license.
  <!--
  Please provide reliable evidence of this.
  NOTE: for compatible licenses, you must make sure to add the included license somewhere in the program, if so required.
  (And even if it's not required, it's still nice to do it. Also add attribution somewhere.)
  -->
