### PR TITLE
minestom: remove fine-grained biome control from minestom

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -89,6 +89,6 @@ object Versions {
     }
     
     object Minestom {
-        const val minestom = "1_21_6-c3ccee696b"
+        const val minestom = "1_21_6-a40d7115d4"
     }
 }

--- a/platforms/minestom/example/src/main/java/com/dfsek/terra/minestom/TerraMinestomExample.java
+++ b/platforms/minestom/example/src/main/java/com/dfsek/terra/minestom/TerraMinestomExample.java
@@ -44,7 +44,6 @@ public class TerraMinestomExample {
     public void attachTerra() {
         world = platform.worldBuilder(instance)
             .defaultPack()
-            .doFineGrainedBiomes(false)
             .attach();
     }
 

--- a/platforms/minestom/src/main/java/com/dfsek/terra/minestom/api/TerraMinestomWorldBuilder.java
+++ b/platforms/minestom/src/main/java/com/dfsek/terra/minestom/api/TerraMinestomWorldBuilder.java
@@ -22,7 +22,6 @@ public class TerraMinestomWorldBuilder {
     private EntityFactory entityFactory = new DefaultEntityFactory();
     private BlockEntityFactory blockEntityFactory;
     private BiomeFactory biomeFactory = new MinestomUserDefinedBiomeFactory();
-    private boolean doFineGrainedBiomes = true;
 
     public TerraMinestomWorldBuilder(TerraMinestomPlatform platform, Instance instance) {
         this.platform = platform;
@@ -70,20 +69,7 @@ public class TerraMinestomWorldBuilder {
         return this;
     }
 
-    /**
-     * Due to a current bug with the minestom biome encoder, sometimes, the client gets kicked when decoding a chunk
-     * packet with more than one biome. Until this is fixed in minestom, one can disable fine-grained biomes to prevent
-     * this issue.
-     *
-     * @deprecated Scheduled for removal once Minestom rolls out a fix
-     */
-    @Deprecated
-    public TerraMinestomWorldBuilder doFineGrainedBiomes(boolean doFineGrainedBiomes) {
-        this.doFineGrainedBiomes = doFineGrainedBiomes;
-        return this;
-    }
-
     public TerraMinestomWorld attach() {
-        return new TerraMinestomWorld(platform, instance, pack, seed, entityFactory, blockEntityFactory, biomeFactory, doFineGrainedBiomes);
+        return new TerraMinestomWorld(platform, instance, pack, seed, entityFactory, blockEntityFactory, biomeFactory);
     }
 }

--- a/platforms/minestom/src/main/java/com/dfsek/terra/minestom/biome/MinestomUserDefinedBiomePool.java
+++ b/platforms/minestom/src/main/java/com/dfsek/terra/minestom/biome/MinestomUserDefinedBiomePool.java
@@ -1,6 +1,8 @@
 package com.dfsek.terra.minestom.biome;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
 
 import com.dfsek.terra.api.config.ConfigPack;
 import com.dfsek.terra.api.world.biome.Biome;
@@ -8,7 +10,8 @@ import com.dfsek.terra.minestom.api.BiomeFactory;
 
 
 public class MinestomUserDefinedBiomePool {
-    private final HashMap<String, UserDefinedBiome> biomes = new HashMap<>();
+    private final IdentityHashMap<Biome, UserDefinedBiome> biomes = new IdentityHashMap<>();
+    private final HashSet<String> createdBiomes = new HashSet<>();
     private final BiomeFactory factory;
     private final ConfigPack configPack;
 
@@ -18,18 +21,21 @@ public class MinestomUserDefinedBiomePool {
     }
 
     public UserDefinedBiome getBiome(Biome source) {
-        UserDefinedBiome userDefinedBiome = biomes.get(source.getID());
+        UserDefinedBiome userDefinedBiome = biomes.get(source);
         if(userDefinedBiome != null) return userDefinedBiome;
         userDefinedBiome = factory.create(configPack, source);
-        biomes.put(source.getID(), userDefinedBiome);
+        biomes.put(source, userDefinedBiome);
+        createdBiomes.add(source.getID());
         return userDefinedBiome;
     }
 
     public void preloadBiomes(Iterable<Biome> biomesToLoad) {
         biomesToLoad
             .forEach(biome -> {
-                if(!this.biomes.containsKey(biome.getID())) {
-                    this.biomes.put(biome.getID(), factory.create(configPack, biome));
+                if(!this.createdBiomes.contains(biome.getID())) {
+                    UserDefinedBiome udf = factory.create(configPack, biome);
+                    this.biomes.put(biome, udf);
+                    this.createdBiomes.add(biome.getID());
                 }
             });
     }

--- a/platforms/minestom/src/main/java/com/dfsek/terra/minestom/biome/UserDefinedBiome.java
+++ b/platforms/minestom/src/main/java/com/dfsek/terra/minestom/biome/UserDefinedBiome.java
@@ -1,9 +1,49 @@
 package com.dfsek.terra.minestom.biome;
 
 import net.kyori.adventure.key.Key;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.registry.DynamicRegistry;
 import net.minestom.server.registry.RegistryKey;
 import net.minestom.server.world.biome.Biome;
 
 
-public record UserDefinedBiome(Key key, RegistryKey<Biome> registry, String id, Biome biome) {
+public class UserDefinedBiome {
+    private static final DynamicRegistry<Biome> BIOME_REGISTRY = MinecraftServer.getBiomeRegistry();
+
+    private final Key key;
+    private final RegistryKey<Biome> registry;
+    private final String id;
+    private final Biome biome;
+
+    private int registryId = -1;
+
+    public UserDefinedBiome(Key key, RegistryKey<Biome> registry, String id, Biome biome) {
+        this.key = key;
+        this.registry = registry;
+        this.id = id;
+        this.biome = biome;
+    }
+
+    public Key key() {
+        return key;
+    }
+
+    public RegistryKey<Biome> registryKey() {
+        return registry;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public Biome biome() {
+        return biome;
+    }
+
+    public int registryId() {
+        if(registryId == -1) {
+            registryId = BIOME_REGISTRY.getId(registry);
+        }
+        return registryId;
+    }
 }

--- a/platforms/minestom/src/main/java/com/dfsek/terra/minestom/world/TerraMinestomWorld.java
+++ b/platforms/minestom/src/main/java/com/dfsek/terra/minestom/world/TerraMinestomWorld.java
@@ -44,8 +44,7 @@ public final class TerraMinestomWorld implements ServerWorld, WorldProperties {
         long seed,
         EntityFactory entityFactory,
         BlockEntityFactory blockEntityFactory,
-        BiomeFactory factory,
-        boolean doFineGrainedBiomes
+        BiomeFactory factory
     ) {
         this.instance = instance;
         this.pack = pack;
@@ -55,12 +54,10 @@ public final class TerraMinestomWorld implements ServerWorld, WorldProperties {
         this.blockEntityFactory = blockEntityFactory;
 
         this.wrapper = new MinestomChunkGeneratorWrapper(
-            platform,
             pack.getGeneratorProvider().newInstance(pack),
             this,
             pack,
-            new MinestomUserDefinedBiomePool(pack, factory),
-            doFineGrainedBiomes
+            new MinestomUserDefinedBiomePool(pack, factory)
         );
         this.entityFactory = entityFactory;
 


### PR DESCRIPTION
# Pull Request

## Description

Remove the temporary feature flag for minestom biome handling. Does not require the discussed PR on the minestom side; we're faster either way.

Also implements object-based ID caching for performance reason.

![image](https://github.com/user-attachments/assets/00c8636b-8eb7-4dff-865e-494227da6b0c)

Biomes don't even come up in the intellij profiler if you look for 'em

## Checklist

<!--
Select the options below that apply.
You must put an x in all the boxes that it applies to. (Like this: [x])
-->

#### Mandatory checks

- [x] The base branch of this PR is an unreleased version branch (that has a `ver/` prefix)
  or is a branch that is intended to be merged into a version branch.
  <!--
  This is not applicable if the PR is a version branch itself.
  PRs for new versions should use the `master` branch instead.
  -->
- [x] There are no already existing PRs that provide the same changes.
  <!-- If this is not applicable, the PR will be removed as a duplicate. -->
- [x] The PR is within the scope of Terra (i.e. is something a configurable terrain generator should be doing).
- [x] Changes follow the code style for this project.
  <!-- There is an included `.editorconfig` file in the base of the repo. Please use a plugin for your IDE of choice that follows those settings. -->
- [x] I have read the [`CONTRIBUTING.md`](https://github.com/PolyhedralDev/Terra/blob/master/CONTRIBUTING.md)
  document in the root of the git repository.

#### Types of changes

- [ ] Bug Fix <!-- Changes include bug fixes. -->
- [ ] Build system <!-- Changes the build system. -->
- [ ] Documentation <!-- Changes add to or improve documentation. -->
- [ ] New Feature <!-- Changes add new functionality to Terra. -->
- [x] Performance <!-- Changes improve the performance of Terra. -->
- [ ] Refactoring <!-- Changes do not add any new code, only moves code around. -->
- [ ] Repository <!-- Changes affect the repository. E.g. changes to the `README.md` file. -->
- [ ] Revert <!-- Changes revert previous commits. -->
- [ ] Style <!-- Changes update style, namely the .editorconfig file. -->
- [ ] Tests <!-- Changes add or update tests. -->
- [ ] Translation <!-- Changes include translations to other languages for Terra. -->

#### Compatibility

<!-- The following options determine if the PR pertains to a major, minor, or patch version bump -->

- [x] Introduces a breaking change
  <!--
  Breaking changes are any fix or feature that breaks some previous functionality to Terra / is not backwards compatible.
  Breaking changes do not include:
    - changes that are backwards compatible and will work with *any* previously existing supported features.
    - changes to code marked as in a pre-release
      state (annotated with @Incubating, @Preview, @Experimental
      or in a package called something similar to the previous annotations)
  -->
- [ ] Introduces new functionality in a backwards compatible way.
- [ ] Introduces bug fixes

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Testing

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  <!--
  Tests are typically not necessary for small changes.
  Including *some* testing is recommended for large changes where applicable.
  -->

#### Licensing

<!-- In order to be accepted, your changes must be under the GPLv3 license. Please check one of the following: -->

- [x] I am the original author of this code, and I am willing to
  release it under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html).
- [ ] I am not the original author of this code, but it is in public domain or
  released under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html) or a compatible license.
  <!--
  Please provide reliable evidence of this.
  NOTE: for compatible licenses, you must make sure to add the included license somewhere in the program, if so required.
  (And even if it's not required, it's still nice to do it. Also add attribution somewhere.)
  -->
