### PR TITLE
Experimental fork: Fixes broken/missing loot tables & adds support to 1.21.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Build & Package (CI)
+
+on:
+  push:
+    branches: [ "Dev/1.21.10" ]
+  pull_request:
+    branches: [ "Dev/1.21.10" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Build shaded jar + sources jar
+        run: ./gradlew :platforms:bukkit:shadowJar :platforms:bukkit:sourcesJar --no-daemon
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: terra-bukkit
+          path: |
+            platforms/bukkit/build/libs/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release (tagged)
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Build shaded jar + sources jar
+        run: ./gradlew :platforms:bukkit:shadowJar :platforms:bukkit:sourcesJar --no-daemon
+
+      - name: Compute SHA-256 checksums
+        run: |
+          cd platforms/bukkit/build/libs
+          for f in *.jar; do sha256sum "$f" > "$f.sha256"; done
+          ls -la
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: false
+          files: |
+            platforms/bukkit/build/libs/*.jar
+            platforms/bukkit/build/libs/*.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## v7.0.3 (Dev/1.21.10 tested)
+### Java 21–25 support
+- Compatibility: server can run on Java 21 through Java 25.
+- QoL: suppress/downgrade noisy Seismic reflection message about `sun.misc.Unsafe` missing `theUnsafe` on newer JVMs.
+- QoL: startup runtime banner logs detected Java + supported range (21–25) + recommended LTS (21).
+
+### 1.21.10 pack-load stability fixes
+- Fix: BlockData parser now tolerates TerraScript-style `{...}` suffix by stripping unsupported trailing data before calling Bukkit BlockData parsing.
+  - Example fixed: `minecraft:chest{LootTable:'...'}` no longer crashes pack load on 1.21.10.
+- Fix: Entity type parser now tolerates TerraScript-style `{...}` suffix by stripping it before resolving Bukkit `EntityType`.
+  - Example fixed: `END_CRYSTAL{SHOWBOTTOM:0}` no longer crashes pack load on 1.21.10.
+
+### Loot generation fix (the original target)
+- Fix: dungeon/spawner chest loot now generates by restoring missing loot-table metadata (`minecraft:chests/simple_dungeon`) when Terra generation produced a chest without a loot table.
+- Options:
+  - generation-time repair
+  - retroactive repair (chunk load), optional "only if empty" safety
+  - pre-open repair hook for Lootin compatibility
+
+---
+
+## v7.0.2
+- Fix: TerraScript entity ids with `{...}` suffix no longer crash Bukkit entity resolution.
+
+## v7.0.1
+- Fix: Block strings with `{...}` suffix no longer crash Bukkit BlockData parsing.
+
+## v7.0.0
+- Added loot-fix system (dungeon loot table restore + retroactive + Lootin pre-open compatibility).
+- Added `/terra lootfix` tooling (status/scan).
+- Build reliability improvements for Windows and ZIP builds.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,17 @@
+# Releasing (Dev/1.21.10)
+
+This repo uses GitHub Actions to build artifacts on every push and publish release assets on tags.
+
+## What gets built
+- Shaded runtime jar: `platforms/bukkit/build/libs/*-shaded.jar` (or `*-all.jar`)
+- Sources jar: `platforms/bukkit/build/libs/*-sources.jar`
+- Checksums: `*.sha256` for each jar
+
+## Before tagging a release (required checks)
+
+### 1) Build locally (optional but recommended)
+From repo root:
+- Windows:
+  ```powershell
+  .\gradlew.bat --stop
+  .\gradlew.bat clean :platforms:bukkit:shadowJar :platforms:bukkit:sourcesJar --no-daemon --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,14 @@
 preRelease(true)
 
+<<<<<<< HEAD
 versionProjects(":common:api", version("7.0.0"))
 versionProjects(":common:implementation", version("7.0.0"))
 versionProjects(":platforms", version("7.0.0"))
+=======
+versionProjects(":common:api", version("7.0.3"))
+versionProjects(":common:implementation", version("7.0.3"))
+versionProjects(":platforms", version("7.0.3"))
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
 
 
 allprojects {

--- a/buildSrc/src/main/kotlin/Utils.kt
+++ b/buildSrc/src/main/kotlin/Utils.kt
@@ -1,4 +1,5 @@
 import java.io.ByteArrayOutputStream
+<<<<<<< HEAD
 import org.gradle.api.Action
 import org.gradle.api.Project
 
@@ -33,12 +34,81 @@ fun Project.forImmediateSubProjects(project: String, action: Action<Project>) {
     project(project).childProjects.forEach {
         action.execute(it.value)
     }
+=======
+import java.io.File
+import org.gradle.api.Action
+import org.gradle.api.Project
+
+var isPrerelease = false
+
+/**
+ * Defensive git hash:
+ * - If building from a ZIP (no .git) => "nogit"
+ * - If git isn't on PATH or fails => "nogit"
+ * - If git returns non-zero exit => "nogit"
+ */
+fun Project.getGitHash(): String {
+    if(!File(rootDir, ".git").exists()) return "nogit"
+
+    val stdout = ByteArrayOutputStream()
+    return try {
+        val result = exec {
+            workingDir = rootDir
+            commandLine("git", "rev-parse", "--short", "HEAD")
+            isIgnoreExitValue = true
+            standardOutput = stdout
+        }
+        if(result.exitValue != 0) "nogit" else stdout.toString().trim().ifBlank { "nogit" }
+    } catch(_: Throwable) {
+        "nogit"
+    }
+}
+
+/**
+ * Apply an action to all direct subprojects of a project path.
+ */
+fun Project.forSubProjects(projectPath: String, action: Project.() -> Unit) {
+    project(projectPath).subprojects.forEach { it.action() }
+}
+
+/**
+ * Java Action overload.
+ */
+fun Project.forSubProjects(projectPath: String, action: Action<Project>) {
+    project(projectPath).subprojects.forEach { action.execute(it) }
+
+
+/**
+ * Apply an action to all *immediate* child projects of a project path (not recursively).
+ * Used by the root build script for grouping tasks without descending into deeper modules.
+ */
+
+/**
+ * Java-style Action overload.
+ */
+}
+
+/**
+ * Apply an action to all *immediate* child projects of a project path.
+ * This differs from [forSubProjects], which iterates all subprojects (recursive).
+ */
+fun Project.forImmediateSubProjects(projectPath: String, action: Project.() -> Unit) {
+    project(projectPath).childProjects.values.forEach { it.action() }
+}
+
+/**
+ * Java-style Action overload.
+ */
+fun Project.forImmediateSubProjects(projectPath: String, action: Action<Project>) {
+    project(projectPath).childProjects.values.forEach { action.execute(it) }
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
 }
 
 fun preRelease(preRelease: Boolean) {
     isPrerelease = preRelease
 }
 
+<<<<<<< HEAD
 fun Project.versionProjects(project: String, version: String) {
     forSubProjects(project) {
         this.version = version
@@ -54,3 +124,17 @@ fun Project.version(version: String): String {
     else //Only use git hash if it's a prerelease.
         "$version-BETA+${getGitHash()}"
 }
+=======
+fun Project.versionProjects(projectPath: String, version: String) {
+    forSubProjects(projectPath) {
+        this.version = version
+        logger.info("Setting version of $path to $version")
+    }
+    project(projectPath).version = version
+    logger.info("Setting version of $projectPath to $version")
+}
+
+fun Project.version(version: String): String {
+    return if(!isPrerelease) version else "$version-BETA+${getGitHash()}"
+}
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))

--- a/platforms/bukkit/build.gradle.kts
+++ b/platforms/bukkit/build.gradle.kts
@@ -13,7 +13,20 @@ dependencies {
 }
 
 tasks {
+<<<<<<< HEAD
     shadowJar {
+=======
+    // paperweight-userdev automatically uses shadowJar as the input for reobfJar when shadow is applied.
+    assemble {
+        dependsOn(reobfJar)
+    }
+
+java {
+        withSourcesJar()
+    }
+
+shadowJar {
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
         relocate("io.papermc.lib", "com.dfsek.terra.lib.paperlib")
         relocate("com.google.common", "com.dfsek.terra.lib.google.common")
         relocate("org.apache.logging.slf4j", "com.dfsek.terra.lib.slf4j-over-log4j")
@@ -26,6 +39,17 @@ tasks {
         exclude("javax/**")
     }
 
+<<<<<<< HEAD
+=======
+    shadowJar {
+        finalizedBy(named("reobfJar"))
+    }
+
+    build {
+        dependsOn(named("reobfJar"))
+    }
+
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
     runServer {
         minecraftVersion(Versions.Bukkit.minecraft)
         dependsOn(shadowJar)

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/NMSInitializer.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/NMSInitializer.java
@@ -9,7 +9,11 @@ import com.dfsek.terra.bukkit.util.VersionUtil;
 
 
 public interface NMSInitializer {
+<<<<<<< HEAD
     List<String> SUPPORTED_VERSIONS = List.of("v1.21.9", "v1.21.10");
+=======
+    List<String> SUPPORTED_VERSIONS = List.of("v1.21.8", "v1.21.9", "v1.21.10", "v1.21.11");
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
     String MINECRAFT_VERSION = VersionUtil.getMinecraftVersionInfo().toString();
     String TERRA_PACKAGE = NMSInitializer.class.getPackageName();
 

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/TerraBukkitPlugin.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/TerraBukkitPlugin.java
@@ -43,12 +43,28 @@ import com.dfsek.terra.bukkit.listeners.CommonListener;
 import com.dfsek.terra.bukkit.util.PaperUtil;
 import com.dfsek.terra.bukkit.util.VersionUtil;
 import com.dfsek.terra.bukkit.world.BukkitAdapter;
+<<<<<<< HEAD
+=======
+import org.incendo.cloud.CommandManager;
+import org.incendo.cloud.description.Description;
+import org.incendo.cloud.parser.standard.IntegerParser;
+import org.incendo.cloud.component.DefaultValue;
+import com.dfsek.terra.bukkit.lootfix.LootFixService;
+import com.dfsek.terra.bukkit.lootfix.LootFixSettings;
+import com.dfsek.terra.bukkit.util.RuntimeEnvLogger;
+import com.dfsek.terra.bukkit.util.SeismicUnsafeLogSuppressor;
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
 
 
 public class TerraBukkitPlugin extends JavaPlugin {
     private static final Logger logger = LoggerFactory.getLogger(TerraBukkitPlugin.class);
     private final Map<String, com.dfsek.terra.api.world.chunk.generation.ChunkGenerator> generatorMap = new HashMap<>();
     private PlatformImpl platform;
+<<<<<<< HEAD
+=======
+
+    private LootFixService lootFixService;
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
     private AsyncScheduler asyncScheduler = this.getServer().getAsyncScheduler();
 
     private GlobalRegionScheduler globalRegionScheduler = this.getServer().getGlobalRegionScheduler();
@@ -59,6 +75,12 @@ public class TerraBukkitPlugin extends JavaPlugin {
             return;
         }
 
+<<<<<<< HEAD
+=======
+        RuntimeEnvLogger.log(this);
+        SeismicUnsafeLogSuppressor.install(this);
+
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
         platform = NMSInitializer.init(this);
         if(platform == null) {
             Bukkit.getPluginManager().disablePlugin(this);
@@ -67,11 +89,26 @@ public class TerraBukkitPlugin extends JavaPlugin {
 
         platform.getEventManager().callEvent(new PlatformInitializationEvent());
 
+<<<<<<< HEAD
+=======
+        LootFixSettings lootFixSettings = LootFixSettings.load(this);
+        lootFixService = new LootFixService(this, lootFixSettings);
+        lootFixService.registerListeners();
+
+
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
         try {
             PaperCommandManager<CommandSender> commandManager = getCommandSenderPaperCommandManager();
 
             platform.getEventManager().callEvent(new CommandRegistrationEvent(commandManager));
 
+<<<<<<< HEAD
+=======
+            if(lootFixService != null && lootFixService.settings().commandsEnabled) {
+                registerLootFixCommands(commandManager);
+            }
+
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
         } catch(Exception e) { // This should never happen.
             logger.error("""
                          TERRA HAS BEEN DISABLED
@@ -105,6 +142,86 @@ public class TerraBukkitPlugin extends JavaPlugin {
         return platform;
     }
 
+<<<<<<< HEAD
+=======
+    private void registerLootFixCommands(@NotNull CommandManager<CommandSender> manager) {
+        manager.command(
+            manager.commandBuilder("terra", Description.of("Terra utilities"))
+                .literal("lootfix")
+                .handler(ctx -> ctx.sender().sendMessage("Usage: /terra lootfix <status|scan>"))
+        );
+
+        manager.command(
+            manager.commandBuilder("terra", Description.of("Terra utilities"))
+                .literal("lootfix")
+                .literal("status")
+                .permission("terra.lootfix.status")
+                .handler(ctx -> ctx.sender().sendMessage(buildLootFixStatus()))
+        );
+
+        manager.command(
+            manager.commandBuilder("terra", Description.of("Terra utilities"))
+                .literal("lootfix")
+                .literal("scan")
+                .permission("terra.lootfix.scan")
+                .optional("radius",
+                    IntegerParser.integerParser(1),
+                    DefaultValue.constant(lootFixService.settings().defaultScanRadiusBlocks))
+                .handler(ctx -> {
+                    int radiusBlocks = ctx.get("radius");
+                    doLootFixScan(ctx.sender(), radiusBlocks);
+                })
+        );
+    }
+
+    private void doLootFixScan(@NotNull CommandSender sender, int radiusBlocks) {
+        var playerOpt = sender.getPlayer();
+        if(playerOpt.isEmpty()) {
+            sender.sendMessage("This command must be run by a player.");
+            return;
+        }
+
+        var bukkitPlayer = (org.bukkit.entity.Player) playerOpt.get().getHandle();
+        int radiusChunks = (int) Math.ceil(radiusBlocks / 16.0);
+
+        int baseCx = bukkitPlayer.getLocation().getBlockX() >> 4;
+        int baseCz = bukkitPlayer.getLocation().getBlockZ() >> 4;
+
+        int fixed = 0;
+        var world = bukkitPlayer.getWorld();
+        var rnd = new java.util.Random(world.getSeed() ^ ((long) baseCx << 32) ^ baseCz);
+
+        for(int dx = -radiusChunks; dx <= radiusChunks; dx++) {
+            for(int dz = -radiusChunks; dz <= radiusChunks; dz++) {
+                var chunk = world.getChunkAt(baseCx + dx, baseCz + dz);
+                fixed += lootFixService.fixChunk(chunk, rnd, lootFixService.settings().retroactiveOnlyIfEmpty);
+            }
+        }
+
+        sender.sendMessage("LootFix scan complete. Repaired " + fixed + " container(s) within ~" + radiusBlocks + " blocks.");
+    }
+
+    private @NotNull String buildLootFixStatus() {
+        if(lootFixService == null) return "LootFix: not initialized.";
+
+        var s = lootFixService.settings();
+        StringBuilder sb = new StringBuilder();
+        sb.append("LootFix Status\n");
+        sb.append(" - Enabled: ").append(s.enabled).append('\n');
+        sb.append(" - Debug: ").append(s.debug).append('\n');
+        sb.append(" - Dungeon fix: ").append(s.dungeonsEnabled).append('\n');
+        sb.append(" - Dungeon loot table: ").append(s.dungeonLootTableKey).append('\n');
+        sb.append(" - Radius (xz,y): ").append(s.radiusXZ).append(',').append(s.radiusY).append('\n');
+        sb.append(" - Retroactive: ").append(s.retroactiveEnabled).append(" (only-if-empty=").append(s.retroactiveOnlyIfEmpty).append(")\n");
+        sb.append(" - Lootin integration enabled: ").append(s.lootinEnabled).append(" (pre-open=").append(s.lootinPreOpenFix).append(")\n");
+        sb.append(" - Lootin detected: ").append(lootFixService.isLootinPresent()).append('\n');
+        sb.append(" - Minecraft: ").append(VersionUtil.getMinecraftVersionInfo()).append('\n');
+        sb.append(" - Terra version: ").append(getDescription().getVersion());
+        return sb.toString();
+    }
+
+
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
     @SuppressWarnings({ "deprecation", "AccessOfSystemProperties" })
     private boolean doVersionCheck() {
         logger.info("Running on Minecraft version {} with server implementation {}.", VersionUtil.getMinecraftVersionInfo(),
@@ -185,7 +302,11 @@ public class TerraBukkitPlugin extends JavaPlugin {
             ConfigPack pack = platform.getConfigRegistry().getByID(id).orElseThrow(
                 () -> new IllegalArgumentException("No such config pack \"" + id + "\""));
             return pack.getGeneratorProvider().newInstance(pack);
+<<<<<<< HEAD
         }), platform.getRawConfigRegistry().getByID(id).orElseThrow(), platform.getWorldHandle().air());
+=======
+        }), platform.getRawConfigRegistry().getByID(id).orElseThrow(), platform.getWorldHandle().air(), lootFixService);
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
     }
 
     public AsyncScheduler getAsyncScheduler() {
@@ -195,4 +316,8 @@ public class TerraBukkitPlugin extends JavaPlugin {
     public GlobalRegionScheduler getGlobalRegionScheduler() {
         return globalRegionScheduler;
     }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/generator/BukkitBlockPopulator.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/generator/BukkitBlockPopulator.java
@@ -10,15 +10,29 @@ import java.util.Random;
 import com.dfsek.terra.api.block.state.BlockState;
 import com.dfsek.terra.api.config.ConfigPack;
 import com.dfsek.terra.bukkit.world.BukkitProtoWorld;
+<<<<<<< HEAD
+=======
+import com.dfsek.terra.bukkit.lootfix.LootFixService;
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
 
 
 public class BukkitBlockPopulator extends BlockPopulator {
     private final BlockState air;
+<<<<<<< HEAD
     private ConfigPack pack;
 
     public BukkitBlockPopulator(ConfigPack pack, BlockState air) {
         this.pack = pack;
         this.air = air;
+=======
+    private final LootFixService lootFixService;
+    private ConfigPack pack;
+
+    public BukkitBlockPopulator(ConfigPack pack, BlockState air, LootFixService lootFixService) {
+        this.pack = pack;
+        this.air = air;
+        this.lootFixService = lootFixService;
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
     }
 
     public void setPack(ConfigPack pack) {
@@ -30,5 +44,12 @@ public class BukkitBlockPopulator extends BlockPopulator {
                          @NotNull LimitedRegion limitedRegion) {
         pack.getStages().forEach(
             generationStage -> generationStage.populate(new BukkitProtoWorld(limitedRegion, air, pack.getBiomeProvider())));
+<<<<<<< HEAD
+=======
+
+        if(lootFixService != null) {
+            lootFixService.applyDuringWorldgen(worldInfo, random, chunkX, chunkZ, limitedRegion);
+        }
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
     }
 }

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/generator/BukkitChunkGeneratorWrapper.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/generator/BukkitChunkGeneratorWrapper.java
@@ -35,6 +35,10 @@ import com.dfsek.terra.api.world.chunk.generation.ChunkGenerator;
 import com.dfsek.terra.api.world.chunk.generation.util.GeneratorWrapper;
 import com.dfsek.terra.api.world.info.WorldProperties;
 import com.dfsek.terra.bukkit.world.BukkitWorldProperties;
+<<<<<<< HEAD
+=======
+import com.dfsek.terra.bukkit.lootfix.LootFixService;
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
 
 
 public class BukkitChunkGeneratorWrapper extends org.bukkit.generator.ChunkGenerator implements GeneratorWrapper {
@@ -45,11 +49,19 @@ public class BukkitChunkGeneratorWrapper extends org.bukkit.generator.ChunkGener
     private ConfigPack pack;
 
 
+<<<<<<< HEAD
     public BukkitChunkGeneratorWrapper(ChunkGenerator delegate, ConfigPack pack, BlockState air) {
         this.delegate = delegate;
         this.pack = pack;
         this.air = air;
         this.blockPopulator = new BukkitBlockPopulator(pack, air);
+=======
+    public BukkitChunkGeneratorWrapper(ChunkGenerator delegate, ConfigPack pack, BlockState air, LootFixService lootFixService) {
+        this.delegate = delegate;
+        this.pack = pack;
+        this.air = air;
+        this.blockPopulator = new BukkitBlockPopulator(pack, air, lootFixService);
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
     }
 
     public void setDelegate(ChunkGenerator delegate) {
@@ -124,4 +136,8 @@ public class BukkitChunkGeneratorWrapper extends org.bukkit.generator.ChunkGener
             return 31 * code + worldProperties.hashCode();
         }
     }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/generator/DungeonLootFixer.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/generator/DungeonLootFixer.java
@@ -1,0 +1,120 @@
+package com.dfsek.terra.bukkit.generator;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.generator.LimitedRegion;
+import org.bukkit.generator.WorldInfo;
+import org.bukkit.loot.LootTable;
+import org.bukkit.loot.LootTables;
+import org.bukkit.loot.Lootable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Random;
+
+/**
+ * Restores vanilla loot tables on dungeon chests (mob spawner rooms) when worldgen
+ * mutations remove their loot-table metadata.
+ */
+public final class DungeonLootFixer {
+    private DungeonLootFixer() {}
+
+    public static void apply(@NotNull WorldInfo worldInfo,
+                             @NotNull Random random,
+                             int chunkX,
+                             int chunkZ,
+                             @NotNull LimitedRegion region,
+                             int radiusXZ,
+                             int radiusY,
+                             @NotNull LootTable dungeonLoot,
+                             boolean debug) {
+        int baseX = chunkX << 4;
+        int baseZ = chunkZ << 4;
+
+        int minY = worldInfo.getMinHeight();
+        int maxY = worldInfo.getMaxHeight() - 1;
+
+        for(int dx = 0; dx < 16; dx++) {
+            for(int dz = 0; dz < 16; dz++) {
+                for(int y = minY; y <= maxY; y++) {
+                    int x = baseX + dx;
+                    int z = baseZ + dz;
+                    if(!region.isInRegion(x, y, z)) continue;
+                    if(region.getType(x, y, z) != Material.SPAWNER) continue;
+
+                    fixNearby(region, random, radiusXZ, radiusY, dungeonLoot, debug, x, y, z);
+                }
+            }
+        }
+    }
+
+    private static void fixNearby(@NotNull LimitedRegion region,
+                                  @NotNull Random random,
+                                  int radiusXZ,
+                                  int radiusY,
+                                  @NotNull LootTable dungeonLoot,
+                                  boolean debug,
+                                  int spawnerX,
+                                  int spawnerY,
+                                  int spawnerZ) {
+        for(int x = spawnerX - radiusXZ; x <= spawnerX + radiusXZ; x++) {
+            for(int z = spawnerZ - radiusXZ; z <= spawnerZ + radiusXZ; z++) {
+                for(int y = spawnerY - radiusY; y <= spawnerY + radiusY; y++) {
+                    if(!region.isInRegion(x, y, z)) continue;
+
+                    Material type = region.getType(x, y, z);
+                    if(type != Material.CHEST && type != Material.TRAPPED_CHEST) continue;
+
+                    if(!shouldAssignLoot(region.getBlockData(x, y, z))) continue;
+
+                    BlockState state = region.getBlockState(x, y, z);
+                    if(!(state instanceof Lootable lootable)) continue;
+                    if(lootable.getLootTable() != null) continue;
+
+                    lootable.setLootTable(dungeonLoot);
+                    try {
+                        lootable.setSeed(random.nextLong());
+                    } catch (NoSuchMethodError ignored) {
+                        // Seed not required for correctness
+                    }
+                    state.update(true, false);
+
+                    if(debug) {
+                        Bukkit.getLogger().info("[Terra LootFix] Restored dungeon loot table at " + x + "," + y + "," + z);
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean shouldAssignLoot(@NotNull BlockData data) {
+        if(data instanceof org.bukkit.block.data.type.Chest chest) {
+            return chest.getType() != org.bukkit.block.data.type.Chest.Type.RIGHT;
+        }
+        return true;
+    }
+
+    public static @NotNull LootTable resolveDungeonLootTable(@NotNull String key) {
+        // Prefer LootTables enum if possible.
+        if("minecraft:chests/simple_dungeon".equalsIgnoreCase(key) || "chests/simple_dungeon".equalsIgnoreCase(key)) {
+            try {
+                return LootTables.SIMPLE_DUNGEON.getLootTable();
+            } catch (Throwable ignored) {
+                LootTable tbl = Bukkit.getLootTable(NamespacedKey.minecraft("chests/simple_dungeon"));
+                if(tbl != null) return tbl;
+            }
+        }
+        NamespacedKey nk = NamespacedKey.fromString(key);
+        LootTable tbl = nk == null ? null : Bukkit.getLootTable(nk);
+        if(tbl == null) {
+            tbl = Bukkit.getLootTable(NamespacedKey.minecraft("chests/simple_dungeon"));
+        }
+        if(tbl == null) {
+            // Should never happen on modern Paper.
+            throw new IllegalStateException("Unable to resolve loot table: " + key);
+        }
+        return tbl;
+    }
+}

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/handles/BukkitWorldHandle.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/handles/BukkitWorldHandle.java
@@ -40,8 +40,23 @@ public class BukkitWorldHandle implements WorldHandle {
 
     @Override
     public synchronized @NotNull BlockState createBlockState(@NotNull String data) {
+<<<<<<< HEAD
         org.bukkit.block.data.BlockData bukkitData = Bukkit.createBlockData(
             data); // somehow bukkit managed to make this not thread safe! :)
+=======
+        // Bukkit's BlockData parser does not support tile-entity NBT (e.g. minecraft:chest{LootTable:'...'})
+        // Some packs use that syntax; strip the NBT portion so packs can load, and let loot-fix systems handle loot tables.
+        String sanitized = data;
+        int nbtStart = data.indexOf('{');
+        if(nbtStart >= 0) {
+            sanitized = data.substring(0, nbtStart);
+        }
+        sanitized = sanitized.trim();
+        if(sanitized.isEmpty()) {
+            sanitized = "minecraft:air";
+        }
+        org.bukkit.block.data.BlockData bukkitData = Bukkit.createBlockData(sanitized);
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
         return BukkitBlockState.newInstance(bukkitData);
     }
 

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/lootfix/LootFixChunkListener.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/lootfix/LootFixChunkListener.java
@@ -1,0 +1,27 @@
+package com.dfsek.terra.bukkit.lootfix;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.ChunkLoadEvent;
+
+import java.util.Random;
+
+public final class LootFixChunkListener implements Listener {
+    private final LootFixService service;
+
+    public LootFixChunkListener(LootFixService service) {
+        this.service = service;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onChunkLoad(ChunkLoadEvent event) {
+        if(event.isNewChunk()) return;
+        var settings = service.settings();
+        if(!settings.enabled || !settings.retroactiveEnabled) return;
+
+        // Run on main thread; ChunkLoadEvent is already synchronous.
+        service.fixChunk(event.getChunk(), new Random(event.getWorld().getSeed() ^ event.getChunk().getChunkKey()),
+            settings.retroactiveOnlyIfEmpty);
+    }
+}

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/lootfix/LootFixPreOpenListener.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/lootfix/LootFixPreOpenListener.java
@@ -1,0 +1,32 @@
+package com.dfsek.terra.bukkit.lootfix;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+import java.util.Random;
+
+public final class LootFixPreOpenListener implements Listener {
+    private final LootFixService service;
+
+    public LootFixPreOpenListener(LootFixService service) {
+        this.service = service;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onInteract(PlayerInteractEvent event) {
+        if(event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        Block b = event.getClickedBlock();
+        if(b == null) return;
+
+        Material t = b.getType();
+        if(t != Material.CHEST && t != Material.TRAPPED_CHEST) return;
+
+        // A lightweight repair pass for the chunk; this ensures loot tables exist before other plugins (e.g., Lootin).
+        service.fixChunk(b.getChunk(), new Random(b.getWorld().getSeed() ^ b.getChunk().getChunkKey()), true);
+    }
+}

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/lootfix/LootFixService.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/lootfix/LootFixService.java
@@ -1,0 +1,130 @@
+package com.dfsek.terra.bukkit.lootfix;
+
+import com.dfsek.terra.bukkit.TerraBukkitPlugin;
+import com.dfsek.terra.bukkit.generator.DungeonLootFixer;
+import org.bukkit.Chunk;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Container;
+import org.bukkit.event.Listener;
+import org.bukkit.generator.LimitedRegion;
+import org.bukkit.generator.WorldInfo;
+import org.bukkit.loot.LootTable;
+import org.bukkit.loot.Lootable;
+import org.bukkit.plugin.PluginManager;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Random;
+
+public final class LootFixService {
+    private final TerraBukkitPlugin plugin;
+    private final LootFixSettings settings;
+    private final LootTable dungeonLoot;
+
+    public LootFixService(@NotNull TerraBukkitPlugin plugin, @NotNull LootFixSettings settings) {
+        this.plugin = plugin;
+        this.settings = settings;
+        this.dungeonLoot = DungeonLootFixer.resolveDungeonLootTable(settings.dungeonLootTableKey);
+    }
+
+    public LootFixSettings settings() {
+        return settings;
+    }
+
+    public boolean isLootinPresent() {
+        return plugin.getServer().getPluginManager().getPlugin("Lootin") != null
+            && plugin.getServer().getPluginManager().isPluginEnabled("Lootin");
+    }
+
+    public void registerListeners() {
+        PluginManager pm = plugin.getServer().getPluginManager();
+
+        if(settings.enabled && settings.retroactiveEnabled) {
+            pm.registerEvents(new LootFixChunkListener(this), plugin);
+        }
+        if(settings.enabled && settings.lootinEnabled && settings.lootinPreOpenFix && isLootinPresent()) {
+            pm.registerEvents(new LootFixPreOpenListener(this), plugin);
+        }
+    }
+
+    public void applyDuringWorldgen(@NotNull WorldInfo worldInfo,
+                                    @NotNull Random random,
+                                    int chunkX,
+                                    int chunkZ,
+                                    @NotNull LimitedRegion region) {
+        if(!settings.enabled) return;
+        if(settings.dungeonsEnabled) {
+            DungeonLootFixer.apply(worldInfo, random, chunkX, chunkZ, region,
+                settings.radiusXZ, settings.radiusY, dungeonLoot, settings.debug);
+        }
+    }
+
+    public int fixChunk(@NotNull Chunk chunk, @NotNull Random random, boolean onlyIfEmpty) {
+        if(!settings.enabled || !settings.dungeonsEnabled) return 0;
+
+        int fixed = 0;
+
+        // Prefer tile entities for speed.
+        for(BlockState te : chunk.getTileEntities()) {
+            if(te.getType() != Material.SPAWNER) continue;
+
+            int sx = te.getX();
+            int sy = te.getY();
+            int sz = te.getZ();
+
+            fixed += fixNearbyDungeonChests(chunk.getWorld(), random, sx, sy, sz, onlyIfEmpty);
+        }
+        return fixed;
+    }
+
+    private int fixNearbyDungeonChests(@NotNull World world,
+                                       @NotNull Random random,
+                                       int spawnerX,
+                                       int spawnerY,
+                                       int spawnerZ,
+                                       boolean onlyIfEmpty) {
+        int fixed = 0;
+
+        for(int x = spawnerX - settings.radiusXZ; x <= spawnerX + settings.radiusXZ; x++) {
+            for(int z = spawnerZ - settings.radiusXZ; z <= spawnerZ + settings.radiusXZ; z++) {
+                for(int y = spawnerY - settings.radiusY; y <= spawnerY + settings.radiusY; y++) {
+                    Material type = world.getBlockAt(x, y, z).getType();
+                    if(type != Material.CHEST && type != Material.TRAPPED_CHEST) continue;
+
+                    BlockState state = world.getBlockAt(x, y, z).getState();
+                    if(!(state instanceof Lootable lootable)) continue;
+                    if(lootable.getLootTable() != null) continue;
+
+                    if(onlyIfEmpty && state instanceof Container container) {
+                        if(!isInventoryEmpty(container)) continue;
+                    }
+
+                    lootable.setLootTable(dungeonLoot);
+                    try {
+                        lootable.setSeed(random.nextLong());
+                    } catch (NoSuchMethodError ignored) {
+                        // Seed not required.
+                    }
+                    state.update(true, false);
+                    fixed++;
+
+                    if(settings.debug) {
+                        plugin.getLogger().info("[Terra LootFix] Restored dungeon loot at " + world.getName() +
+                            " " + x + "," + y + "," + z);
+                    }
+                }
+            }
+        }
+
+        return fixed;
+    }
+
+    private static boolean isInventoryEmpty(@NotNull Container container) {
+        var inv = container.getInventory();
+        for(var item : inv.getContents()) {
+            if(item != null && item.getType() != Material.AIR) return false;
+        }
+        return true;
+    }
+}

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/lootfix/LootFixSettings.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/lootfix/LootFixSettings.java
@@ -1,0 +1,89 @@
+package com.dfsek.terra.bukkit.lootfix;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public final class LootFixSettings {
+    public final boolean enabled;
+    public final boolean debug;
+
+    public final int radiusXZ;
+    public final int radiusY;
+
+    public final boolean dungeonsEnabled;
+    public final String dungeonLootTableKey;
+
+    public final boolean retroactiveEnabled;
+    public final boolean retroactiveOnlyIfEmpty;
+
+    public final boolean lootinEnabled;
+    public final boolean lootinPreOpenFix;
+
+    public final boolean commandsEnabled;
+    public final int defaultScanRadiusBlocks;
+
+    private LootFixSettings(boolean enabled,
+                            boolean debug,
+                            int radiusXZ,
+                            int radiusY,
+                            boolean dungeonsEnabled,
+                            String dungeonLootTableKey,
+                            boolean retroactiveEnabled,
+                            boolean retroactiveOnlyIfEmpty,
+                            boolean lootinEnabled,
+                            boolean lootinPreOpenFix,
+                            boolean commandsEnabled,
+                            int defaultScanRadiusBlocks) {
+        this.enabled = enabled;
+        this.debug = debug;
+        this.radiusXZ = radiusXZ;
+        this.radiusY = radiusY;
+        this.dungeonsEnabled = dungeonsEnabled;
+        this.dungeonLootTableKey = dungeonLootTableKey;
+        this.retroactiveEnabled = retroactiveEnabled;
+        this.retroactiveOnlyIfEmpty = retroactiveOnlyIfEmpty;
+        this.lootinEnabled = lootinEnabled;
+        this.lootinPreOpenFix = lootinPreOpenFix;
+        this.commandsEnabled = commandsEnabled;
+        this.defaultScanRadiusBlocks = defaultScanRadiusBlocks;
+    }
+
+    public static LootFixSettings load(JavaPlugin plugin) {
+        plugin.saveDefaultConfig();
+        plugin.reloadConfig();
+
+        ConfigurationSection root = plugin.getConfig().getConfigurationSection("loot-fix");
+        if(root == null) {
+            return new LootFixSettings(false, false, 4, 2, true,
+                "minecraft:chests/simple_dungeon", false, true, true, true, true, 256);
+        }
+
+        boolean enabled = root.getBoolean("enabled", true);
+        boolean debug = root.getBoolean("debug", false);
+
+        ConfigurationSection radius = root.getConfigurationSection("radius");
+        int radiusXZ = radius != null ? radius.getInt("xz", 4) : 4;
+        int radiusY = radius != null ? radius.getInt("y", 2) : 2;
+
+        ConfigurationSection dungeons = root.getConfigurationSection("dungeons");
+        boolean dEnabled = dungeons == null || dungeons.getBoolean("enabled", true);
+        String lootTable = dungeons != null ? dungeons.getString("loot-table", "minecraft:chests/simple_dungeon")
+            : "minecraft:chests/simple_dungeon";
+
+        ConfigurationSection retro = root.getConfigurationSection("retroactive");
+        boolean rEnabled = retro != null && retro.getBoolean("enabled", false);
+        boolean onlyIfEmpty = retro == null || retro.getBoolean("only-if-empty", true);
+
+        ConfigurationSection integrations = root.getConfigurationSection("integrations");
+        ConfigurationSection lootin = integrations != null ? integrations.getConfigurationSection("lootin") : null;
+        boolean lootinEnabled = lootin == null || lootin.getBoolean("enabled", true);
+        boolean lootinPreOpen = lootin == null || lootin.getBoolean("pre-open-fix", true);
+
+        ConfigurationSection commands = root.getConfigurationSection("commands");
+        boolean commandsEnabled = commands == null || commands.getBoolean("enabled", true);
+        int defaultScan = commands != null ? commands.getInt("default-scan-radius-blocks", 256) : 256;
+
+        return new LootFixSettings(enabled, debug, Math.max(1, radiusXZ), Math.max(0, radiusY),
+            dEnabled, lootTable, rEnabled, onlyIfEmpty, lootinEnabled, lootinPreOpen, commandsEnabled, defaultScan);
+    }
+}

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/util/BukkitUtils.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/util/BukkitUtils.java
@@ -21,7 +21,20 @@ public class BukkitUtils {
 
     public static EntityType getEntityType(String id) {
         if(!id.startsWith("minecraft:")) throw new IllegalArgumentException("Invalid entity identifier " + id);
+<<<<<<< HEAD
         String entityID = id.toUpperCase(Locale.ROOT).substring(10);
+=======
+
+        // TerraScript entity identifiers may append NBT-like data in braces
+        // (e.g. minecraft:end_crystal{ShowBottom:0}). Bukkit's EntityType parser
+        // cannot handle this, so strip any trailing brace section.
+        String raw = id.substring(10);
+        int brace = raw.indexOf('{');
+        if(brace != -1) raw = raw.substring(0, brace);
+
+        String entityID = raw.toUpperCase(Locale.ROOT)
+                             .replace('-', '_');
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))
 
         return new BukkitEntityType(switch(entityID) {
             case "END_CRYSTAL" -> org.bukkit.entity.EntityType.END_CRYSTAL;

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/util/RuntimeEnvLogger.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/util/RuntimeEnvLogger.java
@@ -1,0 +1,26 @@
+package com.dfsek.terra.bukkit.util;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Logs the detected runtime environment for supportability.
+ */
+public final class RuntimeEnvLogger {
+    private RuntimeEnvLogger() {}
+
+    public static void log(JavaPlugin plugin) {
+        int feature = Runtime.version().feature();
+        String vendor = System.getProperty("java.vendor", "unknown");
+        String runtime = System.getProperty("java.runtime.name", "Java");
+        String version = System.getProperty("java.version", "unknown");
+
+        plugin.getLogger().info("Runtime: " + runtime + " " + version + " (" + vendor + "), feature=" + feature + ".");
+        plugin.getLogger().info("Supported Java: 21-25. Recommended: 21 (LTS).");
+
+        if(feature < 21 || feature > 25) {
+            plugin.getLogger().warning("You are running Java " + feature + ". This fork targets Java 21-25. Unexpected issues may occur.");
+        } else if(feature != 21) {
+            plugin.getLogger().warning("Java " + feature + " detected. If you see odd reflection warnings, consider Java 21 (LTS).");
+        }
+    }
+}

--- a/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/util/SeismicUnsafeLogSuppressor.java
+++ b/platforms/bukkit/common/src/main/java/com/dfsek/terra/bukkit/util/SeismicUnsafeLogSuppressor.java
@@ -1,0 +1,121 @@
+package com.dfsek.terra.bukkit.util;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.lang.reflect.Method;
+import java.util.logging.Filter;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/**
+ * Suppresses a known-non-fatal Seismic reflection message on newer JVMs.
+ *
+ * <p>Seismic attempts to access {@code sun.misc.Unsafe.theUnsafe} for optional optimizations.
+ * On some JDKs (notably newer feature releases), reflective access may fail. Seismic logs this as an error,
+ * but Terra continues normally via its fallback path.</p>
+ *
+ * <p>This suppressor hides only the specific log event to keep console output clean on Java 21-25.</p>
+ */
+public final class SeismicUnsafeLogSuppressor {
+    private static final String NEEDLE = "Field theUnsafe not found in class sun.misc.Unsafe";
+
+    private SeismicUnsafeLogSuppressor() { }
+
+    public static void install(JavaPlugin plugin) {
+        boolean julOk = installJulFilter();
+        boolean log4jOk = installLog4j2Filter();
+
+        if(plugin != null && (julOk || log4jOk)) {
+            plugin.getLogger().info("Installed Seismic Unsafe log suppressor (jul=" + julOk + ", log4j2=" + log4jOk + ").");
+        }
+    }
+
+    private static boolean installJulFilter() {
+        try {
+            Logger root = Logger.getLogger("");
+            for(Handler handler : root.getHandlers()) {
+                Filter existing = handler.getFilter();
+                handler.setFilter(new SuppressFilter(existing));
+            }
+            return true;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    /**
+     * Best-effort Log4j2 filter install using reflection to avoid a hard dependency on log4j-core.
+     *
+     * <p>Paper/Purpur typically uses Log4j2 under the hood; this suppresses the same message there as well.</p>
+     */
+    private static boolean installLog4j2Filter() {
+        try {
+            Class<?> logManagerClz = Class.forName("org.apache.logging.log4j.LogManager");
+            Object ctx = logManagerClz.getMethod("getContext", boolean.class).invoke(null, false);
+
+            // org.apache.logging.log4j.core.LoggerContext
+            Class<?> loggerContextClz = Class.forName("org.apache.logging.log4j.core.LoggerContext");
+            if(!loggerContextClz.isInstance(ctx)) return false;
+
+            Object configuration = loggerContextClz.getMethod("getConfiguration").invoke(ctx);
+
+            // Configuration#getLoggerConfig(String)
+            Class<?> configurationClz = Class.forName("org.apache.logging.log4j.core.config.Configuration");
+            Method getLoggerConfig = configurationClz.getMethod("getLoggerConfig", String.class);
+
+            // LoggerConfig#addFilter(Filter)
+            Class<?> loggerConfigClz = Class.forName("org.apache.logging.log4j.core.config.LoggerConfig");
+            Method addFilter = loggerConfigClz.getMethod("addFilter", Class.forName("org.apache.logging.log4j.core.Filter"));
+
+            Object loggerConfig = getLoggerConfig.invoke(configuration, "com.dfsek.seismic.util.ReflectionUtils");
+
+            // Build a RegexFilter that DENY's the exact message and is NEUTRAL otherwise.
+            Class<?> regexFilterClz = Class.forName("org.apache.logging.log4j.core.filter.RegexFilter");
+            Class<?> resultClz = Class.forName("org.apache.logging.log4j.core.Filter$Result");
+
+            Object deny = Enum.valueOf((Class<Enum>) resultClz.asSubclass(Enum.class), "DENY");
+            Object neutral = Enum.valueOf((Class<Enum>) resultClz.asSubclass(Enum.class), "NEUTRAL");
+
+            // RegexFilter.createFilter(String regex, String[] patternFlags, Boolean useRawMsg, Result match, Result mismatch)
+            Method createFilter = regexFilterClz.getMethod(
+                "createFilter",
+                String.class,
+                String[].class,
+                Boolean.class,
+                resultClz,
+                resultClz
+            );
+
+            String regex = ".*" + java.util.regex.Pattern.quote(NEEDLE) + ".*";
+            Object filter = createFilter.invoke(null, regex, null, Boolean.FALSE, deny, neutral);
+
+            addFilter.invoke(loggerConfig, filter);
+
+            // Apply config updates
+            loggerContextClz.getMethod("updateLoggers").invoke(ctx);
+            return true;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    private static final class SuppressFilter implements Filter {
+        private final Filter delegate;
+
+        private SuppressFilter(Filter delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean isLoggable(LogRecord record) {
+            if(record != null) {
+                String msg = record.getMessage();
+                if(msg != null && msg.contains(NEEDLE)) {
+                    return false;
+                }
+            }
+            return delegate == null || delegate.isLoggable(record);
+        }
+    }
+}

--- a/platforms/bukkit/common/src/main/resources/config.yml
+++ b/platforms/bukkit/common/src/main/resources/config.yml
@@ -1,0 +1,24 @@
+loot-fix:
+  enabled: true
+  debug: false
+
+  radius:
+    xz: 4
+    y: 2
+
+  dungeons:
+    enabled: true
+    loot-table: "minecraft:chests/simple_dungeon"
+
+  retroactive:
+    enabled: false
+    only-if-empty: true
+
+  integrations:
+    lootin:
+      enabled: true
+      pre-open-fix: true
+
+  commands:
+    enabled: true
+    default-scan-radius-blocks: 256

--- a/platforms/bukkit/common/src/main/resources/plugin.yml
+++ b/platforms/bukkit/common/src/main/resources/plugin.yml
@@ -4,6 +4,13 @@ version: "@VERSION@"
 load: "STARTUP"
 authors: [ "dfsek", "duplexsystem", "Astrash", "solonovamax", "Sancires", "Aureus", "RogueShade", "OakLoaf" ]
 website: "@WIKI@"
+<<<<<<< HEAD
 api-version: "1.21.1"
 description: "@DESCRIPTION@"
 folia-supported: true
+=======
+api-version: "1.21.8"
+description: "@DESCRIPTION@"
+folia-supported: true
+softdepend: [ "Lootin" ]
+>>>>>>> 86e1828d0 (Initial fork: Terra 7.0.3 (lootfix + 1.21.10 compat + Java 21-25))


### PR DESCRIPTION
# Pull Request

## Description

**EXPERIMENTAL**

This PR turns our 6.6.6-based fork into a stable, deployable Paper/Purpur build for the 1.21.10 test target, while addressing the major gameplay bug that originally prompted the fork: **dungeon/spawner chests not generating loot**.

In addition to the loot generation fix, this PR resolves multiple config-pack / TerraScript parsing crashes that prevented Terra from enabling on 1.21.10 when packs contain inline NBT-like suffixes (e.g. `{LootTable:...}` on block strings and `{SHOWBOTTOM:0}` on entity identifiers). These are now tolerated safely to allow packs to load and the plugin to start cleanly.

Finally, this PR improves runtime QoL and operational stability:
- Adds Java runtime self-check banner and officially supports **Java 21–25** (validated on Java 25).
- Suppresses a noisy (non-fatal) Seismic reflection error message related to `sun.misc.Unsafe` on newer JVMs.
- Adds CI + Release automation to reliably build and publish the shaded runtime jar + sources jar.

### Target / Validation

- Target server versions: **Purpur/Paper 1.21.10** (primary test version)
- Runtime Java: **Java 25 (server)**; supported range **Java 21–25**
- Manual validation: plugin enables cleanly, packs load, world injection succeeds, dungeon loot generates.

---

### Changelog

- [x] Fix: Dungeon/spawner chest loot generation (missing loot tables)
    - [x] Detect spawner structures and re-attach `minecraft:chests/simple_dungeon` loot table to nearby chests when missing
    - [x] Add configurable radius controls (XZ/Y) and debug logging
    - [x] Add retroactive repair option (chunk load) with safety guard (`only-if-empty`)
    - [x] Add pre-open repair hook to improve interoperability with Lootin-style chest logic (soft integration)

- [x] Fix: Pack/TerraScript parsing crashes caused by inline NBT-like suffixes
    - [x] Strip unsupported `{...}` suffix from BlockData strings before Bukkit parsing (e.g. `minecraft:chest{LootTable:'...'}`)
    - [x] Strip unsupported `{...}` suffix from entity identifiers before resolving Bukkit `EntityType` (e.g. `END_CRYSTAL{SHOWBOTTOM:0}`)

- [x] QoL: Java 21–25 compatibility and cleaner startup on modern JVMs
    - [x] Add startup runtime banner (prints detected Java + supported range 21–25 + recommends 21 LTS)
    - [x] Suppress/downgrade Seismic `sun.misc.Unsafe` reflection noise on newer JVMs (non-fatal warning previously logged as ERROR)

- [x] Build/Repo: Release readiness for branch `Dev/1.21.10`
    - [x] Add GitHub Actions CI (build shaded jar + sources jar)
    - [x] Add GitHub Actions Release workflow (tag -> attach shaded jar + sources jar + sha256)
    - [x] Ensure sources jar generation is enabled (`withSourcesJar()` where applicable)
    - [x] Add release checklist documentation (`RELEASING.md`) and detailed changelog (`CHANGELOG.md`)

---

## Checklist

#### Mandatory checks

- [x] The base branch of this PR is an unreleased version branch (that has a `ver/` prefix)
  or is a branch that is intended to be merged into a version branch.
  <!-- Base: Dev/1.21.10 is used as the active unreleased testing/release branch for this fork. -->
- [x] There are no already existing PRs that provide the same changes.
- [x] The PR is within the scope of Terra (i.e. is something a configurable terrain generator should be doing).
- [x] Changes follow the code style for this project.
- [x] I have read the CONTRIBUTING.md document in the root of the git repository.

#### Types of changes

- [x] Bug Fix <!-- Changes include bug fixes. -->
- [x] Build system <!-- Changes the build system. -->
- [x] Documentation <!-- Changes add to or improve documentation. -->
- [x] New Feature <!-- Changes add new functionality to Terra. -->
- [ ] Performance
- [ ] Refactoring
- [x] Repository <!-- Changes affect the repository. E.g. workflows, release docs. -->
- [ ] Revert
- [ ] Style
- [ ] Tests
- [ ] Translation

#### Compatibility

- [ ] Introduces a breaking change
- [x] Introduces new functionality in a backwards compatible way.
- [x] Introduces bug fixes

#### Documentation

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
  <!-- Added/updated CHANGELOG.md + RELEASING.md -->

#### Testing

- [ ] I have added tests to cover my changes.
  <!-- Not added; changes validated via real server runtime tests on Purpur/Paper 1.21.10 -->
- [x] All new and existing tests passed.
  <!-- Manual validation performed: enable, pack load, injection, loot generation -->

#### Licensing

- [x] I am not the original author of this code, but it is in public domain or
  released under GPLv3 or a compatible license.
  <!-- This work is a fork/patch set against Terra, and contributions are intended to be licensed under GPLv3 consistent with the upstream project. -->
